### PR TITLE
Cease using SSE4.2 instructions for CRC

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -18,7 +18,7 @@ HASH_FILES := $(FMTIOC_DIST)
 endif
 SCOUTFS_FORMAT_HASH := $(shell cat $(HASH_FILES) | md5sum | cut -b1-16)
 
-CFLAGS := -Wall -O2 -Werror -D_FILE_OFFSET_BITS=64 -g -msse4.2 \
+CFLAGS := -Wall -O2 -Werror -D_FILE_OFFSET_BITS=64 -g \
 	-Wpadded \
 	-fno-strict-aliasing \
 	-DSCOUTFS_FORMAT_HASH=0x$(SCOUTFS_FORMAT_HASH)LLU
@@ -47,7 +47,7 @@ endif
 
 $(BIN): $(OBJ)
 	$(QU)  [BIN $@]
-	$(VE)gcc -o $@ $^ -luuid -lm -lcrypto
+	$(VE)gcc -o $@ $^ -luuid -lm -lcrypto -lz
 
 %.o %.d: %.c Makefile sparse.sh
 	$(QU)  [CC $<]

--- a/utils/src/crc.c
+++ b/utils/src/crc.c
@@ -1,26 +1,12 @@
+#include <zlib.h>
+
 #include "crc.h"
 #include "util.h"
 #include "format.h"
 
 u32 crc32c(u32 crc, const void *data, unsigned int len)
 {
-	while (len >= 8) {
-		crc = __builtin_ia32_crc32di(crc, *(u64 *)data);
-		len -= 8;
-		data += 8;
-	}
-	if (len & 4) {
-		crc = __builtin_ia32_crc32si(crc, *(u32 *)data);
-		data += 4;
-	}
-	if (len & 2) {
-		crc = __builtin_ia32_crc32hi(crc, *(u16 *)data);
-		data += 2;
-	}
-	if (len & 1)
-		crc = __builtin_ia32_crc32qi(crc, *(u8 *)data);
-
-	return crc;
+	return crc32(crc, data, len);
 }
 
 /* A simple hack to get reasonably solid 64bit hash values */


### PR DESCRIPTION
Prev code caused mkfs to fail to run on CPUs without SSE4.2.

(This includes my colo box, where I'm trying to get self-hosted CI working from.)

Remove hand-coded CRC calc in favor of implementation from zlib. zlib
is already an implicit dependency (for openssl) so no additional
packages required.

Signed-off-by: Andy Grover <agrover@versity.com>