### PR TITLE
Fix mkfs check for existing ScoutFS superblock

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -304,7 +304,7 @@ if [ -n "$T_UNMOUNT" ]; then
 fi
 
 if [ -n "$T_MKFS" ]; then
-	cmd scoutfs mkfs -Q "$T_QUORUM" "$T_META_DEVICE" "$T_DATA_DEVICE"
+	cmd scoutfs mkfs -Q "$T_QUORUM" "$T_META_DEVICE" "$T_DATA_DEVICE" -f
 fi
 
 if [ -n "$T_INSMOD" ]; then

--- a/utils/src/blkid.c
+++ b/utils/src/blkid.c
@@ -71,7 +71,7 @@ static int check_bdev_scoutfs(int fd, char *devname, char *usage)
 	if (ret)
 		return ret;
 
-	if (le32_to_cpu(super->hdr.magic) == SCOUTFS_SUPER_MAGIC) {
+	if (le32_to_cpu(super->hdr.magic) == SCOUTFS_BLOCK_MAGIC_SUPER) {
 		fprintf(stderr, "%s: appears to contain an existing "
 			"ScoutFS superblock\n", devname);
 		ret = -EINVAL;


### PR DESCRIPTION
We were checking for the wrong magic value.

We now need to use -f when running mkfs in run-tests for things to work.

Signed-off-by: Andy Grover <agrover@versity.com>