### PR TITLE
utils: Do not assert if release is given unaligned offset or length

### DIFF
--- a/utils/src/stage_release.c
+++ b/utils/src/stage_release.c
@@ -8,7 +8,6 @@
 #include <errno.h>
 #include <string.h>
 #include <limits.h>
-#include <assert.h>
 #include <argp.h>
 
 #include "sparse.h"
@@ -207,9 +206,6 @@ static int do_release(struct release_args *args)
 			args->path, strerror(errno), errno);
 		return ret;
 	}
-
-	assert(args->offset % SCOUTFS_BLOCK_SM_SIZE == 0);
-	assert(args->length % SCOUTFS_BLOCK_SM_SIZE == 0);
 
 	ioctl_args.offset = args->offset;
 	ioctl_args.length = args->length;


### PR DESCRIPTION
This is checked for by the kernel ioctl code, so giving unaligned values
will return an error, instead of aborting with an assert.

Signed-off-by: Andy Grover <agrover@versity.com>