### PR TITLE
Disable mount-unmount-race test

### DIFF
--- a/tests/sequence
+++ b/tests/sequence
@@ -25,7 +25,8 @@ lock-conflicting-batch-commit.sh
 cross-mount-data-free.sh
 persistent-item-vers.sh
 setup-error-teardown.sh
-mount-unmount-race.sh
+# failing in jenkins pr runners, zab's working on it
+#umount-unmount-race.sh
 createmany-parallel-mounts.sh
 archive-light-cycle.sh
 stale-btree-read.sh


### PR DESCRIPTION
The mount-unmount-race test is occasionally hanging, disable it while we
debug it and have test coverage for unrelated work.

Signed-off-by: Zach Brown <zab@versity.com>