### PR TITLE
Add fenced systemd and example configs

### DIFF
--- a/utils/fenced/scoutfs-fenced.conf.example
+++ b/utils/fenced/scoutfs-fenced.conf.example
@@ -1,0 +1,3 @@
+SCOUTFS_FENCED_DELAY=1
+SCOUTFS_FENCED_RUN=/usr/libexec/scoutfs-fenced/run/local-force-unmount
+SCOUTFS_FENCED_RUN_ARGS=""

--- a/utils/fenced/scoutfs-fenced.service
+++ b/utils/fenced/scoutfs-fenced.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=ScoutFS fenced
+
+StartLimitIntervalSec=500
+StartLimitBurst=5
+
+[Service]
+Restart=on-failure
+RestartSec=5s
+
+ExecStart=/usr/libexec/scoutfs-fenced/scoutfs-fenced
+
+[Install]
+WantedBy=default.target

--- a/utils/scoutfs-utils.spec.in
+++ b/utils/scoutfs-utils.spec.in
@@ -56,10 +56,14 @@ install -m 644 -D src/ioctl.h $RPM_BUILD_ROOT%{_includedir}/scoutfs/ioctl.h
 install -m 644 -D src/format.h $RPM_BUILD_ROOT%{_includedir}/scoutfs/format.h
 install -m 755 -D fenced/scoutfs-fenced $RPM_BUILD_ROOT%{_libexecdir}/scoutfs-fenced/scoutfs-fenced
 install -m 755 -D fenced/local-force-unmount $RPM_BUILD_ROOT%{_libexecdir}/scoutfs-fenced/run/local-force-unmount
+install -m 644 -D fenced/scoutfs-fenced.service $RPM_BUILD_ROOT%{_unitdir}/scoutfs-fenced.service
+install -m 644 -D fenced/scoutfs-fenced.conf.example $RPM_BUILD_ROOT%{_sysconfdir}/scoutfs/scoutfs-fenced.conf.example
 
 %files
 %defattr(644,root,root,755)
 %{_mandir}/man*/scoutfs*.gz
+%{_unitdir}/scoutfs-fenced.service
+%{_sysconfdir}/scoutfs
 %defattr(755,root,root,755)
 %{_sbindir}/scoutfs
 %{_libexecdir}/scoutfs-fenced


### PR DESCRIPTION
This should be good enough to get single node mounts up and running with
fenced with minimal effort.  The example config will need to be copied
to /etc/scoutfs/scoutfs-fenced.conf for it to be functional, so this
still requires specific opt-in and wont accidentally run for multi-node
systems.

Signed-off-by: Ben McClelland <ben.mcclelland@versity.com>