### PR TITLE
Fix client/server abort conn on force unmount

### DIFF
--- a/kmod/src/btree.c
+++ b/kmod/src/btree.c
@@ -1233,10 +1233,6 @@ static int btree_walk(struct super_block *sb,
 	    WARN_ON_ONCE((flags & (BTW_GET_PAR|BTW_SET_PAR)) && !par_root))
 		return -EINVAL;
 
-	/* all ops come through walk and walk calls all reads */
-	if (scoutfs_forcing_unmount(sb))
-		return -EIO;
-
 	scoutfs_inc_counter(sb, btree_walk);
 
 restart:

--- a/kmod/src/client.c
+++ b/kmod/src/client.c
@@ -668,3 +668,11 @@ void scoutfs_client_destroy(struct super_block *sb)
 	kfree(client);
 	sbi->client_info = NULL;
 }
+
+void scoutfs_client_net_shutdown(struct super_block *sb)
+{
+	struct client_info *client = SCOUTFS_SB(sb)->client_info;
+
+	if (client && client->conn)
+		scoutfs_net_shutdown(sb, client->conn);
+}

--- a/kmod/src/client.h
+++ b/kmod/src/client.h
@@ -35,6 +35,7 @@ int scoutfs_client_clear_volopt(struct super_block *sb, struct scoutfs_volume_op
 int scoutfs_client_resize_devices(struct super_block *sb, struct scoutfs_net_resize_devices *nrd);
 int scoutfs_client_statfs(struct super_block *sb, struct scoutfs_net_statfs *nst);
 
+void scoutfs_client_net_shutdown(struct super_block *sb);
 int scoutfs_client_setup(struct super_block *sb);
 void scoutfs_client_destroy(struct super_block *sb);
 

--- a/kmod/src/super.c
+++ b/kmod/src/super.c
@@ -271,6 +271,8 @@ static void scoutfs_umount_begin(struct super_block *sb)
 
 	scoutfs_warn(sb, "forcing unmount, can return errors and lose unsynced data");
 	sbi->forced_unmount = true;
+
+	scoutfs_client_net_shutdown(sb);
 }
 
 static const struct super_operations scoutfs_super_ops = {

--- a/tests/funcs/filter.sh
+++ b/tests/funcs/filter.sh
@@ -72,6 +72,12 @@ t_filter_dmesg()
 	re="$re|scoutfs .* error reading quorum block"
 	re="$re|scoutfs .* error .* writing quorum block"
 	re="$re|scoutfs .* error .* while checking to delete inode"
+	re="$re|scoutfs .* error .*writing btree blocks.*"
+	re="$re|scoutfs .* error .*writing super block.*"
+	re="$re|scoutfs .* error .* freeing merged btree blocks.*.looping commit del.*upd freeing item"
+	re="$re|scoutfs .* error .* freeing merged btree blocks.*.final commit del.upd freeing item"
+	re="$re|scoutfs .* error .*reading quorum block.*to update event.*"
+	re="$re|scoutfs .* error.*server failed to bind to.*"
 
 	egrep -v "($re)" 
 }


### PR DESCRIPTION
Currently when running certain test cases the code will
hang indefinitely due to forced unmount not clearing up
scoutfs_net_sync_request. The fix here is to call
scoutfs_net_shutdown early for the client and server in order
to clear up the pending message queues.