### PR TITLE
Fix xattr update out of bounds access

### DIFF
--- a/kmod/src/xattr.c
+++ b/kmod/src/xattr.c
@@ -368,7 +368,7 @@ static int change_xattr_items(struct inode *inode, u64 id,
 	}
 
 	/* update dirtied overlapping existing items, last partial first */
-	for (i = old_parts - 1; i >= 0; i--) {
+	for (i = min(old_parts, new_parts) - 1; i >= 0; i--) {
 		off = i * SCOUTFS_XATTR_MAX_PART_SIZE;
 		bytes = min_t(unsigned int, new_bytes - off,
 			      SCOUTFS_XATTR_MAX_PART_SIZE);

--- a/tests/golden/simple-xattr-unit
+++ b/tests/golden/simple-xattr-unit
@@ -16,3 +16,4 @@ setfattr: /mnt/test/test/simple-xattr-unit/file: Numerical result out of range
 setfattr: /mnt/test/test/simple-xattr-unit/file: Argument list too long
 === good length boundaries
 === 500 random lengths
+=== alternate val size between interesting sizes


### PR DESCRIPTION
As we update xattrs we need to update any existing old items with the
contents of the new xattr that uses those items.   The loop that updated
existing items only took the old xattr size into account and assumed
that the new xattr would use those items.   If the new xattr size used
fewer parts then the attempt to update all the old parts that weren't
covered by the new size would go very wrong.   The length of the region
in the new xattr would be negative so it'd try to use the max part
length.  Worse, it'd copy these max part length regions outside the
input new xattr buffer.  Typically this would land in addressible memory
and copy garbage into the unused old items before they were later
deleted.

However, it could access so far outside the input buffer that it could
cross a page boudary into inaccessible memory and fault.  We saw this in
the field while trying to repeatedly incrementally shrink a large xattr.

This fixes the loop that updates overlapping items between the new and
old xattr to start with the smaller of their two item counts.  Now it
will only update items that are actually used by both xattrs and will
only safely access the new xattr input buffer.

Signed-off-by: Zach Brown <zab@versity.com>