### PR TITLE
Add scoutfs status to parse filesystem information

### DIFF
--- a/utils/src/status.c
+++ b/utils/src/status.c
@@ -1,0 +1,97 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <argp.h>
+
+#include "util.h"
+#include "cmd.h"
+#include "parse.h"
+
+#define SCOUTFS_STATUS_PATH "/usr/lib/python3.6/site-packages/scoutfs_status/scoutfs.py"
+
+struct status_args {
+    char *cmd;
+    char *function;
+    char *options;
+};
+
+static int parse_opt(int key, char *arg, struct argp_state *state)
+{
+    struct status_args *args = state->input;
+    
+    switch(key) {
+        case 'j':
+            args->options = strdup_or_error(state, "--json");
+            break;
+        case 's':
+            args->options = strdup_or_error(state, "--summary");
+            break;
+        case 'd':
+            args->options = strdup_or_error(state, "--detail");
+            break;
+        case ARGP_KEY_ARG:
+            if (args->cmd) {
+                args->function = strdup_or_error(state, arg);
+            } else {
+                args->cmd = strdup_or_error(state, arg);
+            }
+            break;
+        default:
+            break;
+        }
+    return 0;
+}
+
+static struct argp_option options[] = {
+    { "json", 'j', NULL, 0, "Print in JSON Format"},
+    { "summary", 's', NULL, 0, "Print in Table Format"},
+    { "detail", 'd', NULL, 0, "Print in Multiline Format"},
+    { NULL }
+};
+
+static struct argp argp = {
+    options,
+    parse_opt,
+    "",
+    "Status of ScoutFS filesystem"
+};
+
+static int status_cmd(int argc, char **argv)
+{
+    struct status_args args = {NULL};
+    char str[100] = "python3 ";
+    int ret = 0;
+
+    strcat(strcat(str,SCOUTFS_STATUS_PATH), " ");
+
+    ret = argp_parse(&argp, argc, argv, 0, NULL, &args);
+    if (ret)
+        return ret;
+
+    if (args.options) {
+        strcat(str, args.options);
+        strcat(str, " ");
+    }
+    if (args.cmd)
+        strcat(str,args.cmd);
+    if (args.function)
+        strcat(strcat(str, " "),args.function);
+    system(str);
+
+    return 0;
+}
+
+static void __attribute__((constructor)) status_ctor(void)
+{
+    if(access(SCOUTFS_STATUS_PATH, F_OK) == 0) {
+        cmd_register_argp("status", &argp, GROUP_CORE, status_cmd);
+    } else {
+        return;
+    }
+}

--- a/utils/status/requirements.txt
+++ b/utils/status/requirements.txt
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Versity Software, Inc. All rights reserved.
+#
+
+click
+bson

--- a/utils/status/scoutfs_status/__init__.py
+++ b/utils/status/scoutfs_status/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2021 Versity Software, Inc. All rights reserved.
+#

--- a/utils/status/scoutfs_status/cmd_metadata.py
+++ b/utils/status/scoutfs_status/cmd_metadata.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Versity Software, Inc. All rights reserved.
+#
+
+import click
+import logging
+
+import core
+import util as cliutil
+
+logger = logging.getLogger("scoutfs.cli")
+
+
+@click.group(help="Information about Scoutfs Metadata")
+@cliutil.pass_context
+def sfcli(ctx, **kwargs):
+    pass
+
+
+@sfcli.command(help="Metadata Device Path")
+@cliutil.pass_context
+def show(ctx, **kwargs):
+    path = core.meta_get_path()
+    cliutil.display_output(path, ctx, "systems")

--- a/utils/status/scoutfs_status/cmd_quorum.py
+++ b/utils/status/scoutfs_status/cmd_quorum.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Versity Software, Inc. All rights reserved.
+#
+
+import click
+import logging
+
+import util as cliutil
+
+logger = logging.getLogger("scoutfs.cli")
+
+
+@click.group(help="Information about Scoutfs Quorum")
+@cliutil.pass_context
+def sfcli(ctx, **kwargs):
+    pass
+
+
+@sfcli.command(help="Status of Quorum")
+@cliutil.pass_context
+def status(ctx, **kwargs):
+    pass

--- a/utils/status/scoutfs_status/core.py
+++ b/utils/status/scoutfs_status/core.py
@@ -1,0 +1,161 @@
+import os
+import json
+import logging
+import pwd
+import re
+import glob
+
+import util
+from collections import OrderedDict
+from bson.objectid import ObjectId
+
+logger = logging.getLogger(__name__)
+
+META_PATH = "meta_path"
+
+
+class ScoutfsType:
+    def __init__(self):
+        pass
+
+    def _show_dict(self):
+        clsname = self.__class__.__name__
+        output = {}
+        if clsname not in display_detail_attrs:
+            raise Exception(
+                "Cannot display object: no display_detail_attrs defined for %s" % clsname)
+        for attr in display_detail_attrs[clsname]:
+            value = getattr(self, attr)
+            if isinstance(value, dict):
+                output[attr] = {}
+                for key in value:
+                    output[attr][key] = to_dict(value[key])
+            elif isinstance(value, list):
+                output[attr] = []
+                for element in value:
+                    output[attr].append(to_dict(element))
+            elif isinstance(value, ObjectId):
+                output[attr] = str(value)
+            elif hasattr(value, "_show_dict"):
+                output[attr] = value._show_dict()
+            else:
+                output[attr] = value
+        return output
+
+
+class ScoutfsDisplayEncoder(json.JSONEncoder):
+    def default(self, o):
+        if hasattr(o, "_show_dict"):
+            return o._show_dict()
+        else:
+            return json.JSONEncoder.default(self, o)
+
+
+def to_dict(o):
+    if hasattr(o, "_show_dict"):
+        return o._show_dict()
+    else:
+        return o
+
+
+def to_json(o):
+    return json.dumps(o, indent=4, cls=ScoutfsDisplayEncoder, sort_keys=True)
+
+
+def to_detail_string(o):
+    clsname = o.__class__.__name__
+    if clsname not in display_detail_attrs:
+        raise Exception(
+            "Cannot display object: no display_detail_attrs defined for %s" % clsname)
+    output = "\n"
+    for attr in display_detail_attrs[clsname]:
+        value = getattr(o, attr)
+        value = util.display_string(value)
+        output += "%s: %s\n" % (display_detail_attrs[clsname][attr], value)
+    return output
+
+
+def to_table_string(olist):
+    if not isinstance(olist, list):
+        olist = [olist]
+    if len(olist) < 1:
+        return ""
+    separator = " | "
+    clsname = olist[0].__class__.__name__
+    if clsname not in display_detail_attrs:
+        raise Exception(
+            "Cannot display object: no display_detail_attrs defined for %s" % clsname)
+    col_width = {}
+    for attr in display_table_attrs[clsname]:
+        col_width[attr] = len(display_table_attrs[clsname][attr])
+        for o in olist:
+            value = getattr(o, attr)
+            value = util.display_string(value)
+            setattr(o, attr, value)
+            vlen = len(value)
+            if vlen > col_width[attr]:
+                col_width[attr] = vlen
+    output = ""
+    # Display heading
+    line = []
+    for attr in display_table_attrs[clsname]:
+        line.append(display_table_attrs[clsname][attr].ljust(col_width[attr]))
+    output += separator.join(line)
+    output += "\n" + "-" * len(output) + "\n"
+    # Display rows
+    for o in olist:
+        line = []
+        for attr in display_table_attrs[clsname]:
+            line.append(getattr(o, attr).ljust(col_width[attr]))
+        output += separator.join(line) + "\n"
+    return output
+
+
+TYPE_INT = "integer"
+TYPE_STR = "string"
+TYPE_FLOAT = "float"
+TYPE_BOOL = "boolean"
+
+
+def parse_value(value_str, value_type, value_name):
+    if value_str is None:
+        return None
+    elif value_type == TYPE_STR:
+        return value_str
+    elif value_type == TYPE_INT:
+        return util.to_int(value_str, value_name)
+    elif value_type == TYPE_FLOAT:
+        return util.to_float(value_str, value_name)
+    elif value_type == TYPE_BOOL:
+        return util.to_bool(value_str, value_name)
+    else:
+        raise TypeError("Only STR/INT/FLOAT/BOOL are allowed")
+
+
+display_table_attrs = {}
+display_detail_attrs = {}
+
+display_table_attrs['MetaInfo'] = OrderedDict([
+    ("meta_path", "METADATA PATH"),
+])
+
+display_detail_attrs['MetaInfo'] = OrderedDict([
+    ("meta_path", "METADATA PATH"),
+])
+
+
+class MetaInfo(ScoutfsType):
+    def __init__(self):
+        super().__init__()
+        self.type = "Unknown"
+        self.path = "Unknown"
+
+
+def meta_get_path(**kwargs):
+    pathinfo = MetaInfo()
+    first_line = None
+    for file in glob.iglob('/sys/fs/scoutfs/f.*/mount_options/metadev_path'):
+        with open(file) as f:
+            first_line = f.readline()
+    pathinfo.meta_path = first_line
+    return pathinfo

--- a/utils/status/scoutfs_status/scoutfs.py
+++ b/utils/status/scoutfs_status/scoutfs.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Versity Software, Inc. All rights reserved.
+#
+
+import sys
+import click
+import logging
+import logging.handlers
+import os
+import pwd
+import traceback
+
+import util as cliutil
+
+
+class ScoutfsCLI(click.MultiCommand):
+    def list_commands(self, ctx):
+        ret = []
+        for filename in os.listdir(os.path.dirname(os.path.realpath(__file__))):
+            if filename.endswith('.py') and filename.startswith('cmd_'):
+                ret.append(filename[4:-3])
+        ret.sort()
+        return ret
+
+    def get_command(self, ctx, name):
+        module = None
+        try:
+            module = __import__("cmd_" + name, fromlist=["sfcli"])
+        except ImportError:
+            raise click.BadArgumentUsage("Invalid Command Provided")
+        return module.sfcli
+
+
+@click.command(cls=ScoutfsCLI)
+@click.option("--json", is_flag=True, help="Show output in JSON format.")
+@click.option("--summary", is_flag=True, help="Show output in Table format.")
+@click.option("--detail", is_flag=True, help="Show output in Multiline format. (Default)")
+@cliutil.pass_context
+def sfcli(ctx, json, summary, detail):
+    ctx.json = json
+    ctx.summary = summary
+    ctx.detail = detail
+
+
+if __name__ == "__main__":
+
+    logging.captureWarnings(True)
+    logger = logging.getLogger("scoutfs")
+    logger.setLevel(logging.INFO)
+    handler = logging.handlers.WatchedFileHandler("/tmp/scoutfs.log")
+    handler.setFormatter(logging.Formatter(
+        '[%(asctime)s] %(levelname)s pid-%(process)d %(name)s    %(message)s'))
+    logger.addHandler(handler)
+    logger = logging.getLogger("scoutfs.cli")
+    logger.info("CLI process started: %s")
+
+    try:
+        sfcli()
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("CLI process failed with internal error")
+        click.echo("ERROR: " + e.__class__.__name__ + ": " + str(e), err=True)
+        sys.exit(1)

--- a/utils/status/scoutfs_status/util.py
+++ b/utils/status/scoutfs_status/util.py
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2021 Versity Software, Inc. All rights reserved.
+#
+
+import click
+import core
+
+
+class Context():
+    def __init__(self):
+        self.json = False
+        self.summary = False
+        self.detail = False
+
+
+pass_context = click.make_pass_decorator(Context, ensure=True)
+
+
+def display_output(outval, ctx, typename):
+    if isinstance(outval, list):
+        # For lists, default view is summary
+        if ctx.json:
+            output = {}
+            output['total'] = len(outval)
+            output[typename] = outval
+            click.echo(core.to_json(output))
+        elif ctx.detail:
+            click.echo("TOTAL: %s" % str(len(outval)))
+            for elem in outval:
+                click.echo(core.to_detail_string(elem))
+        else:
+            click.echo(core.to_table_string(outval))
+    else:
+        # For single objects, default view is detail
+        if ctx.json:
+            click.echo(core.to_json(outval))
+        elif ctx.summary:
+            click.echo(core.to_table_string(outval))
+        else:
+            click.echo(core.to_detail_string(outval))
+
+
+def display_string(value):
+    if hasattr(value, "_show_dict"):
+        return re.sub("'", "", str(value.__dict__))
+    elif value is None:
+        return "N/A"
+    return str(value)

--- a/utils/status/setup.py
+++ b/utils/status/setup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Versity Software, Inc. All rights reserved.
+#
+
+from setuptools import setup, find_packages
+
+setup(
+    name='scoutfs_status',
+    version='1.0.0',
+    description='A CLI Tool to get ScoutFS Status',
+    license='GPLv2',
+    author='Bryant Duffy-Ly',
+    author_email='bduffyly@versity.com',
+    url='http://github.com/versity/scoutfs',
+    packages=find_packages(),
+    install_requires=[
+        'click',
+        'bson'
+    ],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+    ],
+)


### PR DESCRIPTION
This patch set is intended to add a python script that would
be a basis for starting a scoutfs status CLI tool to get relevant
information about the filesystem.

The first commit intends to create a bases for future commits
that would build upon the tool.

The first commit contains the laid out structure; the requirements
file that is required to run the python scripts, setup.py to package
the rpm, and lastly the integration into our existing scoutfs CLI.