### PR TITLE
Fix client/server race between lock recov and farewell processing

### DIFF
--- a/kmod/src/net.c
+++ b/kmod/src/net.c
@@ -675,18 +675,28 @@ static void scoutfs_net_recv_worker(struct work_struct *work)
 
 		scoutfs_tseq_add(&ninf->msg_tseq_tree, &mrecv->tseq_entry);
 
+		/* 
+		 * We want to drain the proc_workq in order to ensure that
+		 * that the inflight lock recovery work is fully flushed out
+		 * so that we can prevent the client/server racing trying to
+		 * do lock recovery and processing farewell at the same time.
+		 */
+		if (nh.cmd == SCOUTFS_NET_CMD_FAREWELL && conn->listening_conn)
+			drain_workqueue(conn->proc_workq);
+
 		/*
-		 * Initial received greetings are processed
+		 * Initial received greetings and farewell are processed
 		 * synchronously before any other incoming messages.
 		 *
 		 * Incoming requests or responses to the lock client are
 		 * called synchronously to avoid reordering.
 		 */
 		if (nh.cmd == SCOUTFS_NET_CMD_GREETING ||
+		    (nh.cmd == SCOUTFS_NET_CMD_FAREWELL && conn->listening_conn) ||
 		    (nh.cmd == SCOUTFS_NET_CMD_LOCK && !conn->listening_conn))
 			scoutfs_net_proc_worker(&mrecv->proc_work);
 		else
-			queue_work(conn->workq, &mrecv->proc_work);
+			queue_work(conn->proc_workq, &mrecv->proc_work);
 	}
 
 	if (ret)
@@ -851,6 +861,7 @@ static void scoutfs_net_destroy_worker(struct work_struct *work)
 	}
 
 	destroy_workqueue(conn->workq);
+	destroy_workqueue(conn->proc_workq);
 	scoutfs_tseq_del(&ninf->conn_tseq_tree, &conn->tseq_entry);
 	kfree(conn->info);
 	trace_scoutfs_conn_destroy_free(conn);
@@ -1150,6 +1161,8 @@ static void scoutfs_net_shutdown_worker(struct work_struct *work)
 	/* wait for socket and proc work to finish, includes chained work */
 	drain_workqueue(conn->workq);
 
+	drain_workqueue(conn->proc_workq);
+
 	/* tear down the sock now that all work is done */
 	if (conn->sock) {
 		sock_release(conn->sock);
@@ -1347,10 +1360,20 @@ scoutfs_net_alloc_conn(struct super_block *sb,
 		return NULL;
 	}
 
-	conn->workq = alloc_workqueue("scoutfs_net_%s",
+	conn->workq = alloc_workqueue("scoutfs_net_workq_%s",
 				      WQ_UNBOUND | WQ_NON_REENTRANT, 0,
 				      name_suffix);
 	if (!conn->workq) {
+		kfree(conn->info);
+		kfree(conn);
+		return NULL;
+	}
+
+	conn->proc_workq = alloc_workqueue("scoutfs_net_proc_workq_%s",
+					   WQ_UNBOUND | WQ_NON_REENTRANT, 0,
+					   name_suffix);
+	if (!conn->proc_workq) {
+		destroy_workqueue(conn->workq);
 		kfree(conn->info);
 		kfree(conn);
 		return NULL;
@@ -1386,6 +1409,14 @@ scoutfs_net_alloc_conn(struct super_block *sb,
 	trace_scoutfs_conn_alloc(conn);
 
 	return conn;
+}
+
+/* Give the caller the client info of the connection. This is used by
+ * server processing the server_farewell, and lock response/recovery.
+ */
+void *scoutfs_net_client_info(struct scoutfs_net_connection *conn)
+{
+	return conn->info;
 }
 
 /*

--- a/kmod/src/net.h
+++ b/kmod/src/net.h
@@ -63,6 +63,7 @@ struct scoutfs_net_connection {
 	atomic64_t recv_seq;
 
 	struct workqueue_struct *workq;
+	struct workqueue_struct *proc_workq;
 	struct work_struct listen_work;
 	struct work_struct connect_work;
 	struct work_struct send_work;
@@ -115,6 +116,7 @@ scoutfs_net_alloc_conn(struct super_block *sb,
 		       scoutfs_net_notify_t notify_up,
 		       scoutfs_net_notify_t notify_down, size_t info_size,
 		       scoutfs_net_request_t *req_funcs, char *name_suffix);
+void *scoutfs_net_client_info(struct scoutfs_net_connection *conn);
 u64 scoutfs_net_client_rid(struct scoutfs_net_connection *conn);
 int scoutfs_net_connect(struct super_block *sb,
 			struct scoutfs_net_connection *conn,

--- a/kmod/src/server.c
+++ b/kmod/src/server.c
@@ -122,6 +122,7 @@ struct server_info {
 struct server_client_info {
 	u64 rid;
 	struct list_head head;
+	bool received_farewell;
 };
 
 static __le64 *first_valopt(struct scoutfs_volume_options *valopt)
@@ -1505,10 +1506,14 @@ static int server_lock(struct super_block *sb,
 		       struct scoutfs_net_connection *conn,
 		       u8 cmd, u64 id, void *arg, u16 arg_len)
 {
+	struct server_client_info *sci = scoutfs_net_client_info(conn);
 	u64 rid = scoutfs_net_client_rid(conn);
 
 	if (arg_len != sizeof(struct scoutfs_net_lock))
 		return -EINVAL;
+
+	if (sci->received_farewell)
+		return scoutfs_net_response(sb, conn, cmd, id, -EINVAL, NULL, 0);
 
 	return scoutfs_lock_server_request(sb, rid, id, arg);
 }
@@ -1518,10 +1523,14 @@ static int lock_response(struct super_block *sb,
 			 void *resp, unsigned int resp_len,
 			 int error, void *data)
 {
+	struct server_client_info *sci = scoutfs_net_client_info(conn);
 	u64 rid = scoutfs_net_client_rid(conn);
 
 	if (resp_len != sizeof(struct scoutfs_net_lock))
 		return -EINVAL;
+
+	if (sci->received_farewell)
+		return 0;
 
 	return scoutfs_lock_server_response(sb, rid, resp);
 }
@@ -1560,10 +1569,14 @@ static int lock_recover_response(struct super_block *sb,
 				 void *resp, unsigned int resp_len,
 				 int error, void *data)
 {
+	struct server_client_info *sci = scoutfs_net_client_info(conn);
 	u64 rid = scoutfs_net_client_rid(conn);
 
 	if (invalid_recover(resp, resp_len))
 		return -EINVAL;
+
+	if (sci->received_farewell)
+		return 0;
 
 	return scoutfs_lock_server_recover_response(sb, rid, resp);
 }
@@ -3516,9 +3529,11 @@ static int server_farewell(struct super_block *sb,
 			   struct scoutfs_net_connection *conn,
 			   u8 cmd, u64 id, void *arg, u16 arg_len)
 {
+	struct server_client_info *sci = scoutfs_net_client_info(conn);
 	struct server_info *server = SCOUTFS_SB(sb)->server_info;
 	u64 rid = scoutfs_net_client_rid(conn);
 	struct farewell_request *fw;
+	int ret;
 
 	if (arg_len != 0)
 		return -EINVAL;
@@ -3535,6 +3550,20 @@ static int server_farewell(struct super_block *sb,
 	spin_lock(&server->farewell_lock);
 	list_add_tail(&fw->entry, &server->farewell_requests);
 	spin_unlock(&server->farewell_lock);
+
+	/*
+	 * Tear down client lock server state and set that we recieved farewell
+	 * to ensure that we do not race between client and server trying to process
+	 * lock recovery at the same time (race). We also want to mark that the recovery
+	 * finished so that if client's try to send stuff later; the server doesnt care.
+	 */
+	sci->received_farewell = true;
+	ret = scoutfs_lock_server_farewell(sb, rid);
+	if (ret < 0) {
+		kfree(fw);
+		return ret;
+	}
+	scoutfs_server_recov_finish(sb, rid, SCOUTFS_RECOV_LOCKS);
 
 	queue_farewell_work(server);
 

--- a/tests/golden/client-unmount-recovery
+++ b/tests/golden/client-unmount-recovery
@@ -1,0 +1,1 @@
+== 60s of unmounting non-quorum clients during recovery

--- a/tests/sequence
+++ b/tests/sequence
@@ -33,6 +33,7 @@ resize-devices.sh
 fence-and-reclaim.sh
 orphan-inodes.sh
 mount-unmount-race.sh
+client-unmount-recovery.sh
 createmany-parallel-mounts.sh
 archive-light-cycle.sh
 block-stale-reads.sh

--- a/tests/tests/client-unmount-recovery.sh
+++ b/tests/tests/client-unmount-recovery.sh
@@ -1,0 +1,61 @@
+#
+# Unmount Server and unmount a client as it's replaying to a remaining server
+#
+
+majority_nr=$(t_majority_count)
+quorum_nr=$T_QUORUM
+
+test "$quorum_nr" == "$majority_nr" && \
+        t_skip "all quorum members make up majority, need more mounts to unmount"
+
+test "$T_NR_MOUNTS" -lt "$T_QUORUM" && \
+        t_skip "Need enough non-quorum clients to unmount"
+
+for i in $(t_fs_nrs); do
+        mounted[$i]=1
+done
+
+LENGTH=60
+echo "== ${LENGTH}s of unmounting non-quorum clients during recovery"
+END=$((SECONDS + LENGTH))
+while [ "$SECONDS" -lt "$END" ]; do
+        sv=$(t_server_nr)
+        rid=$(t_mount_rid $sv)
+        echo "sv $sv rid $rid" >> "$T_TMP.log"
+        sync
+        t_umount $sv &
+
+        for i in $(t_fs_nrs); do
+                if [ "$i" -ge "$quorum_nr" ]; then
+                        t_umount $i &
+                        echo "umount $i pid $pid quo $quorum_nr" \
+                                >> $T_TMP.log
+                        mounted[$i]=0
+                fi
+        done
+
+        wait
+
+        t_mount $sv &
+        for i in $(t_fs_nrs); do
+                if [ "${mounted[$i]}" == 0 ]; then
+                        t_mount $i &
+                fi
+        done
+
+        wait
+
+        declare RID_LIST=$(cat /sys/fs/scoutfs/*/rid | sort -u)
+        read -a rid_arr <<< $RID_LIST
+
+        declare LOCK_LIST=$(cut -d' ' -f 5 /sys/kernel/debug/scoutfs/*/server_locks | sort -u)
+        read -a lock_arr <<< $LOCK_LIST
+
+        for i in "${lock_arr[@]}"; do
+                if [[ ! " ${rid_arr[*]} " =~ " $i " ]]; then
+                        t_fail "RID($i): exists when not mounted"
+                fi
+        done
+done
+
+t_pass


### PR DESCRIPTION
The set of patches creates a unit test to reproduce the race between client
and server handling lock recovery while farewell is being processed.

It also addresses the issue found from the unit test along with fixing some typos.