### PR TITLE
Fix race with lock_server dropping locks/nodes

### DIFF
--- a/kmod/src/block.c
+++ b/kmod/src/block.c
@@ -924,6 +924,9 @@ int scoutfs_block_writer_write(struct super_block *sb,
 	struct blk_plug plug;
 	int ret = 0;
 
+	if (sb == NULL || wri == NULL)
+		return -EIO;
+
 	if (wri->nr_dirty_blocks == 0)
 		return 0;
 

--- a/kmod/src/server.c
+++ b/kmod/src/server.c
@@ -3547,10 +3547,6 @@ static int server_farewell(struct super_block *sb,
 	fw->rid = rid;
 	fw->net_id = id;
 
-	spin_lock(&server->farewell_lock);
-	list_add_tail(&fw->entry, &server->farewell_requests);
-	spin_unlock(&server->farewell_lock);
-
 	/*
 	 * Tear down client lock server state and set that we recieved farewell
 	 * to ensure that we do not race between client and server trying to process
@@ -3563,6 +3559,11 @@ static int server_farewell(struct super_block *sb,
 		kfree(fw);
 		return ret;
 	}
+
+	spin_lock(&server->farewell_lock);
+	list_add_tail(&fw->entry, &server->farewell_requests);
+	spin_unlock(&server->farewell_lock);
+
 	scoutfs_server_recov_finish(sb, rid, SCOUTFS_RECOV_LOCKS);
 
 	queue_farewell_work(server);


### PR DESCRIPTION
Unit tests are currently crashing and failing with various
different issues in regards to racing between server lock
already being dropped and another process trying to free
the locks.

[38064.077599] BUG: unable to handle kernel NULL pointer dereference at           (null)
[38064.077706] IP: [<ffffffffacd8ecf3>] rb_erase+0x1c3/0x360
[38064.078102] PGD 0
[38064.078379] Oops: 0002 [#1] SMP
[38064.078696] Modules linked in: loop scoutfs(OE) snd_hda_codec_generic iosf_mbi crc32_pclmul ghash_clmulni_intel snd_hda_intel snd_hda_codec ppdev aesni_intel snd_hda_core snd_hwdep snd_seq lrw snd_seq_device gf128mul glue_helper ablk_helper snd_pcm cryptd snd_timer pcspkr sg snd joydev virtio_rng virtio_balloon soundcore i2c_piix4 parport_pc parport ip_tables xfs libcrc32c sr_mod cdrom ata_generic pata_acpi virtio_console virtio_blk virtio_net net_failover failover crct10dif_pclmul crct10dif_common crc32c_intel qxl serio_raw drm_kms_helper syscopyarea sysfillrect sysimgblt fb_sys_fops ttm ata_piix drm libata virtio_pci virtio_ring virtio drm_panel_orientation_quirks floppy dm_mirror dm_region_hash dm_log dm_mod
[38064.080614] CPU: 0 PID: 5098 Comm: kworker/u4:20 Kdump: loaded Tainted: G           OE  ------------   3.10.0-1160.49.1.el7.x86_64 #1
[38064.081166] Hardware name: Red Hat KVM, BIOS 0.5.1 01/01/2011
[38064.081699] Workqueue: scoutfs_net_workq_accep scoutfs_net_recv_worker [scoutfs]
[38064.081995] task: ffff9dd4725f8000 ti: ffff9dd45e9c8000 task.ti: ffff9dd45e9c8000
[38064.086745] RIP: 0010:[<ffffffffacd8ecf3>]  [<ffffffffacd8ecf3>] rb_erase+0x1c3/0x360
[38064.088157] RSP: 0018:ffff9dd45e9cbc50  EFLAGS: 00010282
[38064.089527] RAX: ffff9dd45820fd30 RBX: ffff9dd458207100 RCX: ffff9dd45820fd31
[38064.090893] RDX: ffff9dd4f7e30e30 RSI: ffff9dd46440e610 RDI: 0000000000000000
[38064.092192] RBP: ffff9dd45e9cbc50 R08: 0000000000000000 R09: ffff9dd458207140
[38064.093452] R10: 0000000066eb7c01 R11: ffff9dd466eb7800 R12: ffff9dd46440e600
[38064.094692] R13: ffff9dd46440e608 R14: ffff9dd458207100 R15: 3c7c1bf5485c5c96
[38064.095925] FS:  0000000000000000(0000) GS:ffff9dd4ffc00000(0000) knlGS:0000000000000000
[38064.097178] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[38064.098408] CR2: 0000000000000000 CR3: 0000000097106000 CR4: 00000000001406f0
[38064.099669] Call Trace:
[38064.100932]  [<ffffffffc06bbda1>] put_server_lock+0x81/0xc0 [scoutfs]
[38064.102165]  [<ffffffffc06bcb79>] scoutfs_lock_server_farewell+0x179/0x210 [scoutfs]
[38064.103362]  [<ffffffffc06e14d5>] server_farewell+0x95/0x140 [scoutfs]
[38064.104522]  [<ffffffffc06bf119>] scoutfs_net_proc_worker+0x89/0x260 [scoutfs]
[38064.105778]  [<ffffffffacabd51d>] ? drain_workqueue+0x12d/0x170
[38064.106982]  [<ffffffffc06bf75e>] scoutfs_net_recv_worker+0x46e/0x4a0 [scoutfs]
[38064.108179]  [<ffffffffacabde8f>] process_one_work+0x17f/0x440
[38064.109358]  [<ffffffffacabefa6>] worker_thread+0x126/0x3c0
[38064.110519]  [<ffffffffacabee80>] ? manage_workers.isra.26+0x2a0/0x2a0
[38064.111676]  [<ffffffffacac5e61>] kthread+0xd1/0xe0
[38064.112821]  [<ffffffffacac5d90>] ? insert_kthread_work+0x40/0x40
[38064.114037]  [<ffffffffad195df7>] ret_from_fork_nospec_begin+0x21/0x21
[38064.115189]  [<ffffffffacac5d90>] ? insert_kthread_work+0x40/0x40
[38064.116323] Code: 4c 89 07 49 89 c8 48 8b 79 08 48 89 78 10 48 89 41 08 e9 d2 00 00 00 90 48 8b 7a 08 48 89 c1 48 83 c9 01 48 89 78 10 48 89 42 08 <48> 89 0f 48 8b 08 48 89 0a 48 83 e1 fc 48 89 10 0f 84 30 01 00
[38064.118769] RIP  [<ffffffffacd8ecf3>] rb_erase+0x1c3/0x360
[38064.119922]  RSP <ffff9dd45e9cbc50>
[38064.121127] CR2: 0000000000000000

Signed-off-by: Bryant G. Duffy-Ly <bduffyly@versity.com>