### PR TITLE
Clean quorum and format change command docs

### DIFF
--- a/utils/man/scoutfs.8
+++ b/utils/man/scoutfs.8
@@ -15,7 +15,7 @@ environment variable. If that variable is also absent the current working
 directory will be used.
 
 .TP
-.BI "change-format-version [-V, --format-version VERS] [-F|--offline META-DEVICE DATA-DEVICE]"
+.BI "change-format-version [-V, --format-version VERS] [-F|--offline] META-DEVICE DATA-DEVICE"
 .sp
 Change the format version of an existing file system.  The maxmimum
 supported version is used by default.   A specific version in the range
@@ -25,7 +25,7 @@ output of --help.
 .PD 0
 .TP
 .sp
-.B "-F, --offline META-DEVICE DATA-DEVICE"
+.B "-F, --offline"
 Change the format version by writing directly to the metadata and data
 devices.   Like mkfs, this writes directly to the devices without
 protection and must only be used on completely unmounted devices.   The
@@ -43,7 +43,7 @@ the super blocks on both devices.
 .PD
 
 .TP
-.BI "change-quorum-config {-Q|--quorum-slot} NR,ADDR,PORT [-F|--offline META-DEVICE DATA-DEVICE]"
+.BI "change-quorum-config {-Q|--quorum-slot NR,ADDR,PORT} [-F|--offline] META-DEVICE"
 .sp
 Change the quorum configuration for an existing file system.  The new
 configuration completely replaces the old configuration.   Any slots
@@ -61,7 +61,7 @@ multiple arguments as described in the
 .B mkfs
 command.
 .TP
-.B "-F, --offline META-DEVICE"
+.B "-F, --offline"
 Perform the change offline by updating the superblock in the metadata
 device.   The command will read the super block and refuse to make the
 change if it sees any evidence that the metadata device is currently in

--- a/utils/src/change_format_version.c
+++ b/utils/src/change_format_version.c
@@ -222,7 +222,7 @@ static struct argp_option options[] = {
 static struct argp argp = {
 	options,
 	parse_opt,
-	"",
+	"META-DEVICE DATA-DEVICE",
 	"Change format version of an existing ScoutFS filesystem"
 };
 

--- a/utils/src/change_quorum_config.c
+++ b/utils/src/change_quorum_config.c
@@ -147,7 +147,7 @@ static struct argp_option options[] = {
 static struct argp argp = {
 	options,
 	parse_opt,
-	"",
+	"META-DEVICE",
 	"Change quorum slots and addresses of an existing ScoutFS filesystem"
 };
 


### PR DESCRIPTION
The man pages and inline help blurbs for the recently added format
version and quorum config commands incorrectly described the device
arguments which are needed.

Signed-off-by: Zach Brown <zab@versity.com>