### PR TITLE
Fix calls that check for quorum leader

### DIFF
--- a/tests/funcs/fs.sh
+++ b/tests/funcs/fs.sh
@@ -83,7 +83,7 @@ t_fs_nrs()
 t_server_nr()
 {
 	for i in $(t_fs_nrs); do
-		if [ "$(cat $(t_sysfs_path $i)/quorum/is_leader)" == "1" ]; then
+		if [ "$(cat $(t_sysfs_path $i)/quorum/is_leader 2>&1)" == "1" ]; then
 			echo $i
 			return
 		fi
@@ -101,7 +101,7 @@ t_server_nr()
 t_first_client_nr()
 {
 	for i in $(t_fs_nrs); do
-		if [ "$(cat $(t_sysfs_path $i)/quorum/is_leader)" == "0" ]; then
+		if [ "$(cat $(t_sysfs_path $i)/quorum/is_leader 2>&1)" == "0" ]; then
 			echo $i
 			return
 		fi


### PR DESCRIPTION
Currently the calls do not check if the file exists; which in the
client-unmount-recovery unit test where in some cases the is_leader file
might not exist based on timing then the unit test fails. It would be better
to add the extra check in the calls to t_server_nr and t_first_client_nr
to make sure the file exists prior to trying to cat for is_leader.

Signed-off-by: Bryant G. Duffy-Ly <bduffyly@versity.com>