### PR TITLE
Increase server commit dirty block budget

### DIFF
--- a/kmod/src/server.c
+++ b/kmod/src/server.c
@@ -246,10 +246,16 @@ static void server_down(struct server_info *server)
 
 /*
  * The per-holder allocation block use budget balances batching
- * efficiency and concurrency.  We can easily have a few holders per
- * client trying to make concurrent updates in a commit.
+ * efficiency and concurrency.  The larger this gets, the fewer
+ * concurrent server operations can be performed in one commit.  Commits
+ * are immediately written after being dirtied so this really only
+ * limits immediate concurrency under load, not batching over time as
+ * one might expect if commits were long lived.
+ *
+ * The upper bound is determined by the server commit hold path that can
+ * dirty the most blocks.
  */
-#define COMMIT_HOLD_ALLOC_BUDGET 250
+#define COMMIT_HOLD_ALLOC_BUDGET 500
 
 struct commit_hold {
 	struct list_head entry;


### PR DESCRIPTION
We're seeing allocator motion during get_log_trees dirty quite a lot of
blocks, which makes sense.  Let's continue to up the budget.   If we
still need significantly larger budgets we'll want to look into capping
the dirty block use of the allocator extent movers which will mean
changing callers to support partial progress.

Signed-off-by: Zach Brown <zab@versity.com>