### PR TITLE
Set sb->s_time_gran to support nsecs

### DIFF
--- a/kmod/src/super.c
+++ b/kmod/src/super.c
@@ -486,6 +486,7 @@ static int scoutfs_fill_super(struct super_block *sb, void *data, int silent)
 	sb->s_export_op = &scoutfs_export_ops;
 	sb->s_xattr = scoutfs_xattr_handlers;
 	sb->s_flags |= MS_I_VERSION | MS_POSIXACL;
+	sb->s_time_gran = 1;
 
 	/* btree blocks use long lived bh->b_data refs */
 	mapping_set_gfp_mask(sb->s_bdev->bd_inode->i_mapping, GFP_NOFS);


### PR DESCRIPTION
We missed initializing sb->s_time_gran which controls how some parts of the kernel truncate the granularity of nsec in timespec.  Some paths don't use it at all so time would be maintained at full precision.  But other paths, particularly setattr_copy() from userspace and notify_change() from the kernel use it to truncate as times are set.

Setting s_time_gran to 1 maintains full nsec precision.