### PR TITLE
Avoid deadlock from block reclaim in rht resize

### DIFF
--- a/kmod/src/counters.h
+++ b/kmod/src/counters.h
@@ -34,7 +34,7 @@
 	EXPAND_COUNTER(block_cache_shrink_next)			\
 	EXPAND_COUNTER(block_cache_shrink_recent)		\
 	EXPAND_COUNTER(block_cache_shrink_remove)		\
-	EXPAND_COUNTER(block_cache_shrink_restart)		\
+	EXPAND_COUNTER(block_cache_shrink_stop)			\
 	EXPAND_COUNTER(btree_compact_values)			\
 	EXPAND_COUNTER(btree_compact_values_enomem)		\
 	EXPAND_COUNTER(btree_delete)				\


### PR DESCRIPTION
The RCU hash table uses deferred work to resize the hash table.  There's a time during resize when hash table iteration will return EAGAIN until resize makes more progress.  During this time resize can perform GFP_KERNEL allocations.

Our shrinker tries to iterate over its RCU hash table to find blocks to reclaim.  It tries to restart iteration if it gets EAGAIN on the assumption that it will be usable again soon.

Combine the two and our shrinker can get stuck retrying iteration indefinitely because it's shrinking on behalf of the hash table resizing that is trying to allocate the next table before making iteration work again.  We have to stop shrinking in this case so that the resizing caller can proceed.