### PR TITLE
Fix partial preallocation when _contig_only = 0

### DIFF
--- a/tests/golden/data-prealloc
+++ b/tests/golden/data-prealloc
@@ -122,7 +122,6 @@ wrote blk 39
 25.. 1: 
 26.. 6: unwritten
 32.. 1: 
-33.. 6: unwritten
 39.. 1: 
 40.. 1: 
 55.. 1: 
@@ -143,10 +142,8 @@ wrote blk 44
 25.. 1: 
 26.. 6: unwritten
 32.. 1: 
-33.. 6: unwritten
 39.. 1: 
 40.. 1: 
-41.. 3: unwritten
 44.. 1: 
 45.. 3: unwritten
 55.. 1: 
@@ -167,10 +164,8 @@ wrote blk 48
 25.. 1: 
 26.. 6: unwritten
 32.. 1: 
-33.. 6: unwritten
 39.. 1: 
 40.. 1: 
-41.. 3: unwritten
 44.. 1: 
 45.. 3: unwritten
 48.. 1: 
@@ -193,10 +188,8 @@ wrote blk 62
 25.. 1: 
 26.. 6: unwritten
 32.. 1: 
-33.. 6: unwritten
 39.. 1: 
 40.. 1: 
-41.. 3: unwritten
 44.. 1: 
 45.. 3: unwritten
 48.. 1: 
@@ -221,10 +214,8 @@ wrote blk 67
 25.. 1: 
 26.. 6: unwritten
 32.. 1: 
-33.. 6: unwritten
 39.. 1: 
 40.. 1: 
-41.. 3: unwritten
 44.. 1: 
 45.. 3: unwritten
 48.. 1: 
@@ -252,10 +243,8 @@ wrote blk 73
 25.. 1: 
 26.. 6: unwritten
 32.. 1: 
-33.. 6: unwritten
 39.. 1: 
 40.. 1: 
-41.. 3: unwritten
 44.. 1: 
 45.. 3: unwritten
 48.. 1: 
@@ -285,10 +274,8 @@ wrote blk 86
 25.. 1: 
 26.. 6: unwritten
 32.. 1: 
-33.. 6: unwritten
 39.. 1: 
 40.. 1: 
-41.. 3: unwritten
 44.. 1: 
 45.. 3: unwritten
 48.. 1: 
@@ -304,7 +291,6 @@ wrote blk 86
 73.. 1: 
 74.. 5: unwritten
 79.. 2: 
-81.. 5: unwritten
 86.. 1: 
 87.. 2: 
 95.. 1: eof
@@ -320,10 +306,8 @@ wrote blk 92
 25.. 1: 
 26.. 6: unwritten
 32.. 1: 
-33.. 6: unwritten
 39.. 1: 
 40.. 1: 
-41.. 3: unwritten
 44.. 1: 
 45.. 3: unwritten
 48.. 1: 
@@ -339,10 +323,8 @@ wrote blk 92
 73.. 1: 
 74.. 5: unwritten
 79.. 2: 
-81.. 5: unwritten
 86.. 1: 
 87.. 2: 
-89.. 3: unwritten
 92.. 1: 
 93.. 2: unwritten
 95.. 1: eof

--- a/tests/tests/data-prealloc.sh
+++ b/tests/tests/data-prealloc.sh
@@ -168,7 +168,8 @@ print_extents_found $prefix
 # the start, and one at the end.
 #
 # Let's keep this last because it creates a ton of output to read
-# through.
+# through.  The correct output is tied to preallocation strategy so it
+# has to be verified each time we change preallocation.
 #
 echo "== block writes into region allocs hole" 
 t_set_sysfs_mount_option 0 data_prealloc_blocks 8


### PR DESCRIPTION
Data preallocation attempts to allocate large aligned regions of extents.  It tried to fill the hole around a write offset that didn't contain an extent.  It missed the case where there can be multiple extents between the start of the region and the hole. It could try to overwrite these additional existing extents and writes could return EINVAL.

We fix this by trimming the preallocation to start at the write offset if there are any extents in the region before the write offset.