### PR TITLE
Filter out journald rotate messages.

### DIFF
--- a/tests/funcs/filter.sh
+++ b/tests/funcs/filter.sh
@@ -88,5 +88,8 @@ t_filter_dmesg()
 	# change-devices causes loop device resizing
 	re="$re|loop[0-9].* detected capacity change from.*"
 
+	# ignore systemd-journal rotating
+	re="$re|systemd-journald.*"
+
 	egrep -v "($re)" 
 }


### PR DESCRIPTION
On el9 distros systemd-journald will log rotation events into kmesg. Since the default logs on VM images are transient only, they are rotated several times during a single test cycle, causing test failures.