### PR TITLE
Remove seq test from fence-and-reclaim

### DIFF
--- a/tests/tests/fence-and-reclaim.sh
+++ b/tests/tests/fence-and-reclaim.sh
@@ -7,14 +7,11 @@ t_require_mounts 2
 
 #
 # Make sure that all mounts can read the results of a write from each
-# mount.  And make sure that the greatest of all the written seqs is
-# visible after the writes were commited by remote reads.
+# mount.
 #
 check_read_write()
 {
 	local expected
-	local greatest=0
-	local seq
 	local path
 	local saw
 	local w
@@ -25,11 +22,6 @@ check_read_write()
 		eval path="\$T_D${w}/written"
 		echo "$expected" > "$path"
 
-		seq=$(scoutfs stat -s meta_seq $path)
-		if [ "$seq" -gt "$greatest" ]; then
-			greatest=$seq
-		fi
-
 		for r in $(t_fs_nrs); do
 			eval path="\$T_D${r}/written"
 			saw=$(cat "$path")
@@ -38,11 +30,6 @@ check_read_write()
 			fi
 		done
 	done
-
-	seq=$(scoutfs statfs -s committed_seq -p $T_D0)
-	if [ "$seq" -lt "$greatest" ]; then
-		echo "committed_seq $seq less than greatest $greatest"
-	fi
 }
 
 # verify that fenced ran our testing fence script


### PR DESCRIPTION
The fence-and-reclaim test has a little function that runs after fencing and recovery to make sure that all the mounts are operational again. The main thing it does is re-use the same locks across a lot of files to ensure that lock recovery didn't lose any locks that stop forward progress.

But I also threw in a test of the committed_seq machinery, as a bit of belt and suspenders.  The problem is the test is racey.  It samples the seq after the write so the greatest seq it rememebers can be after the write and will not be committed by the other nodes reads.  It being less than the committed_seq is a totally reasonable race.

Which explains why this test has been rarely failing since it was written.  There's no particular reason to test the committed_seq machinery here, so we can just remove that racey test.