### PR TITLE
Store compile logs of xfstests

### DIFF
--- a/tests/tests/xfstests.sh
+++ b/tests/tests/xfstests.sh
@@ -33,7 +33,7 @@ if [ -z "$T_SKIP_CHECKOUT" ]; then
 	# this remote use is bad, do better
 	t_quiet git checkout -B "$T_XFSTESTS_BRANCH" --track "origin/$T_XFSTESTS_BRANCH"
 fi
-t_quiet make
+make > build.log 2>&1
 t_quiet sync
 # pwd stays in xfstests dir to build config and run
 


### PR DESCRIPTION
Occasionally we'll need to see the output of these to figure out build issues on new OS's in our CI.