### PR TITLE
Reduce inode deletion cluster lock hold times

### DIFF
--- a/kmod/src/data.h
+++ b/kmod/src/data.h
@@ -47,8 +47,8 @@ int scoutfs_get_block_write(struct inode *inode, sector_t iblock, struct buffer_
 			    int create);
 
 int scoutfs_data_truncate_items(struct super_block *sb, struct inode *inode,
-				u64 ino, u64 iblock, u64 last, bool offline,
-				struct scoutfs_lock *lock);
+				u64 ino, u64 iblock, u64 last, unsigned txn_limit,
+				bool offline, struct scoutfs_lock *lock);
 int scoutfs_data_fiemap(struct inode *inode, struct fiemap_extent_info *fieinfo,
 			u64 start, u64 len);
 long scoutfs_fallocate(struct file *file, int mode, loff_t offset, loff_t len);

--- a/kmod/src/ioctl.c
+++ b/kmod/src/ioctl.c
@@ -335,7 +335,7 @@ static long scoutfs_ioc_release(struct file *file, unsigned long arg)
 	eblock = (args.offset + args.length - 1) >> SCOUTFS_BLOCK_SM_SHIFT;
 	ret = scoutfs_data_truncate_items(sb, inode, scoutfs_ino(inode),
 					  sblock,
-					  eblock, true,
+					  eblock, 0, true,
 					  lock);
 	if (ret == 0) {
 		scoutfs_inode_get_onoff(inode, &online, &offline);
@@ -345,7 +345,7 @@ static long scoutfs_ioc_release(struct file *file, unsigned long arg)
 					>> SCOUTFS_BLOCK_SM_SHIFT;
 			ret = scoutfs_data_truncate_items(sb, inode,
 							  scoutfs_ino(inode),
-							  sblock, U64_MAX,
+							  sblock, U64_MAX, 0,
 							  false, lock);
 		}
 	}

--- a/tests/funcs/fs.sh
+++ b/tests/funcs/fs.sh
@@ -459,3 +459,17 @@ t_restore_all_sysfs_mount_options() {
 		t_set_sysfs_mount_option $i $name "${_saved_opts[$ind]}"
 	done
 }
+
+#
+# Return success if the inode number still has visible fs items.  This
+# can be used to probe if an inode's items have been fully deleted, or not.
+# This operates under cluster locking so it is coherent with respect to
+# local item deletions which are in the current dirty transaction.
+#
+t_ino_has_items() {
+	local ino="$1"
+	local path="$2"
+
+	scoutfs get-allocated-inos -i "$ino" -s -p "$path" > $T_TMP.inos.log 2>&1
+	test "$?" == 0 -a "$(head -1 $T_TMP.inos.log)" == "$ino"
+}

--- a/tests/golden/enospc
+++ b/tests/golden/enospc
@@ -1,6 +1,6 @@
 == prepare directories and files
 == fallocate until enospc
-== remove all the files and verify free data blocks
+== remove files and check that blocks were freed
 == make small meta fs
 == create large xattrs until we fill up metadata
 == remove files with xattrs after enospc


### PR DESCRIPTION
A lot of file extent manipulation cluster lock hold times are proportional to the number of extents being manipulated because they were modeled on i_mutex patterns.

This can be a problem when there are a truly immense number of extents to work with.  Other callers trying to acquire the inode cluster lock will block and eventually cause hunt task timeout messages.

We have a test that specifically triggers this all the time.  It's made a worse when running in debugging kernels or loaded infrastructure that causes everything to slow down.

The typical solution for this pattern is to limit the amount of work done under each lock hold.  That's hard to solve universally in this case because most callers working on live inodes have visible atomicity promises that stop us from making partial progress visible to other lock acquisition attempts.

So this change is a specific attempt to stop the problem case of deleting the extent items once an inode is fully unlinked and no longer referenced.  In this case we can back out of deletion if we spend too many transactions deleting extent items.  The orphan scanners were already built to support picking up after this kind of interrupted partial progress.