### PR TITLE
Ensure dd creates the full 8K input test file.

### DIFF
--- a/tests/tests/basic-truncate.sh
+++ b/tests/tests/basic-truncate.sh
@@ -11,8 +11,13 @@ FILE="$T_D0/file"
 # final block as we truncated past it.
 #
 echo "== truncate writes zeroed partial end of file block"
-yes | dd of="$FILE" bs=8K count=1 status=none
+yes | dd of="$FILE" bs=8K count=1 status=none iflag=fullblock
 sync
+
+# not passing iflag=fullblock causes the file occasionally to just be
+# 4K, so just to be safe we should at least check size once
+test `stat --printf="%s\n" "$FILE"` -eq 8192 || t_fail "test file incorrect start size"
+
 truncate -s 6K "$FILE"
 truncate -s 12K "$FILE"
 echo 3 > /proc/sys/vm/drop_caches


### PR DESCRIPTION
Without `iflag=fullblock` we encounter sporadic cases where the input file to the truncate test isn't fully written to 8K and ends up to be only 4K. The subsequent truncate tests then fail.

We add a check to the input test file size just to be sure in the future.