### PR TITLE
Fix wrapping detection code blocks.

### DIFF
--- a/kmod/src/client.c
+++ b/kmod/src/client.c
@@ -80,7 +80,7 @@ int scoutfs_client_alloc_inodes(struct super_block *sb, u64 count,
 
 		if (*nr == 0)
 			ret = -ENOSPC;
-		else if (*ino + *nr < *ino)
+		else if ((*ino + (*nr - 1) < *ino) || (*nr < 0))
 			ret = -EINVAL;
 	}
 

--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -1071,7 +1071,7 @@ long scoutfs_fallocate(struct file *file, int mode, loff_t offset, loff_t len)
 	}
 
 	/* catch wrapping */
-	if (offset + len < offset) {
+	if ((len < 0) || (offset + (len - 1) < offset)) {
 		ret = -EINVAL;
 		goto out;
 	}
@@ -1723,7 +1723,8 @@ int scoutfs_data_wait_check(struct inode *inode, loff_t pos, loff_t len,
 	if (WARN_ON_ONCE(sef & SEF_UNKNOWN) ||
 	    WARN_ON_ONCE(op & SCOUTFS_IOC_DWO_UNKNOWN) ||
 	    WARN_ON_ONCE(dw && !RB_EMPTY_NODE(&dw->node)) ||
-	    WARN_ON_ONCE(pos + len < pos)) {
+	    WARN_ON_ONCE(len < 0) ||
+	    WARN_ON_ONCE(pos + (len - 1) < pos)) {
 		ret = -EINVAL;
 		goto out;
 	}

--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -1717,6 +1717,9 @@ int scoutfs_data_wait_check(struct inode *inode, loff_t pos, loff_t len,
 	u64 off;
 	int ret = 0;
 
+	if (len == 0)
+		goto out;
+
 	if (WARN_ON_ONCE(sef & SEF_UNKNOWN) ||
 	    WARN_ON_ONCE(op & SCOUTFS_IOC_DWO_UNKNOWN) ||
 	    WARN_ON_ONCE(dw && !RB_EMPTY_NODE(&dw->node)) ||

--- a/kmod/src/ioctl.c
+++ b/kmod/src/ioctl.c
@@ -293,11 +293,11 @@ static long scoutfs_ioc_release(struct file *file, unsigned long arg)
 
 	if (args.length == 0)
 		return 0;
-	if (((args.offset + args.length) < args.offset) ||
+	if ((args.length < 0) ||
+	    ((args.offset + (args.length - 1)) < args.offset) ||
 	    (args.offset & SCOUTFS_BLOCK_SM_MASK) ||
 	    (args.length & SCOUTFS_BLOCK_SM_MASK))
 		return -EINVAL;
-
 
 	ret = mnt_want_write_file(file);
 	if (ret)

--- a/tests/golden/simple-release-extents
+++ b/tests/golden/simple-release-extents
@@ -4,6 +4,7 @@
 == releasing offline extents is fine
 == 0 count is fine
 == release past i_size is fine
+== max blocks succeeds
 == wrapped blocks fails
 release ioctl failed: Invalid argument (22)
 scoutfs: release failed: Invalid argument (22)

--- a/tests/tests/simple-release-extents.sh
+++ b/tests/tests/simple-release-extents.sh
@@ -60,8 +60,11 @@ release_vers "$FILE" stat 0 0
 echo "== release past i_size is fine"
 release_vers "$FILE" stat 400K 4K
 
-echo "== wrapped blocks fails"
+echo "== max blocks succeeds"
 release_vers "$FILE" stat $vers 0x8000000000000000 0x8000000000000000
+
+echo "== wrapped blocks fails"
+release_vers "$FILE" stat $vers 0x8000000000000000 0x8000000000000001
 
 echo "== releasing non-file fails"
 mknod "$CHAR" c 1 3


### PR DESCRIPTION
A new test from xfstests (generic/525) exposes that we poorly detect wrapping of u64/s64 values in a few cases. The key test is that we should always be able to fully use the last block, where (offset + length) is larger than (e.g.) LLONG_MAX. In other words, we want to make sure length is not negative, and (offset + (length - 1)) doesn't wrap.

scoutfs_client_alloc_inodes() checks that u64 inode numbers do not wrap. We allocate these in 10*1024 hunks, and in practice we will never hit the issue since (2^64 % 10240) is not 0.

scoutfs_fallocate() may hit the wraping issue.

scoutfs_data_wait_check() is the case that was exposed by generic/525.

Our own test `simple-release-extents` almost exposed the wrapping issue in scoutfs_ioc_release(). We adjust the test to test the edge case and the wrapping case properly.