### PR TITLE
More cleanly drive weak-modules on install/uninstall

### DIFF
--- a/kmod/scoutfs-kmod.spec.in
+++ b/kmod/scoutfs-kmod.spec.in
@@ -97,10 +97,21 @@ find %{buildroot} -type f -name \*.ko -exec %{__chmod} u+x \{\} \;
 /lib/modules
 
 %post
-weak-modules --add-kernel --no-initramfs
+echo /lib/modules/%{kversion}/%{install_mod_dir}/scoutfs.ko | weak-modules --add-modules --no-initramfs
 depmod -a
 %endif
 
 %clean
 rm -rf %{buildroot}
 
+%preun
+# stash our modules for postun cleanup
+SCOUTFS_RPM_NAME=$(rpm -q %{name} | grep "%{version}-%{release}")
+rpm -ql $SCOUTFS_RPM_NAME | grep '\.ko$' > /var/run/%{name}-modules-%{version}-%{release} || true
+
+%postun
+if [ -x /sbin/weak-modules ]; then
+    cat /var/run/%{name}-modules-%{version}-%{release} | /sbin/weak-modules --remove-modules --no-initramfs
+fi
+
+rm /var/run/%{name}-modules-%{version}-%{release} || true


### PR DESCRIPTION
This addresses some minor issues with how we handle driving the
weak-modules infrastructure for handling running on kernels not
explicitly built for.

For one, we now drive weak-modules at install-time more explicitly (it
was adding symlinks for all modules into the right place for the running
kernel, whereas now it only handles that for scoutfs against all
installed kernels).

Also we no longer leave stale modules on the filesystem after an
uninstall/upgrade, similar to what's done for vsm's kmods right now.
RPM's pre/postinstall scriptlets are used to drive weak-modules to clean
things up.

Note that this (intentionally) does not regenerate old initrds.

Building this with `set -x` included at the top of both of those scriptlet sections- along with exporting `RPM_SCRIPTLET_DEBUG=1`- yields the correct behavior (similar on el7, everything works the same way):

```
[greg@greg-kmod-test-n0 kmod]$ sudo rpm -ev --scripts kmod-scoutfs 2>&1 |tee kmod-uninstall-output.log
Preparing packages...
++ rpm -q kmod-scoutfs
++ grep 1.19-0.20240401git207e7dc.el8_9
+ SCOUTFS_RPM_NAME=kmod-scoutfs-1.19-0.20240401git207e7dc.el8_9.x86_64
+ rpm -ql kmod-scoutfs-1.19-0.20240401git207e7dc.el8_9.x86_64
+ grep '\.ko$'
kmod-scoutfs-1.19-0.20240401git207e7dc.el8_9.x86_64
+ /sbin/ldconfig
+ '[' -x /sbin/weak-modules ']'
+ cat /var/run/kmod-scoutfs-modules
+ /sbin/weak-modules --remove-modules --no-initramfs
+ rm /var/run/kmod-scoutfs-modules
```