### PR TITLE
Allocate enough space on disk for log_merge

### DIFF
--- a/kmod/scoutfs-kmod.spec.in
+++ b/kmod/scoutfs-kmod.spec.in
@@ -13,8 +13,7 @@
 
 %if 0%{?el7}
 %global kernel_source() /usr/src/kernels/%{kernel_version}.$(arch)
-%endif
-%if 0%{?el8}
+%else
 %global kernel_source() /usr/src/kernels/%{kernel_version}
 %endif
 
@@ -22,8 +21,7 @@
 
 %if 0%{?el7}
 Name:           %{kmod_name}
-%endif
-%if 0%{?el8}
+%else
 Name:           kmod-%{kmod_name}
 %endif
 Summary:        %{kmod_name} kernel module
@@ -35,8 +33,7 @@ URL:            http://scoutfs.org/
 
 %if 0%{?el7}
 BuildRequires:  %{kernel_module_package_buildreqs}
-%endif
-%if 0%{?el8}
+%else
 BuildRequires:  elfutils-libelf-devel
 %endif
 BuildRequires:  kernel-devel-uname-r = %{kernel_version}
@@ -54,7 +51,8 @@ Source:		%{kmod_name}-kmod-%{kmod_version}.tar
 %endif
 
 %global install_mod_dir extra/%{kmod_name}
-%if 0%{?el8}
+
+%if ! 0%{?el7}
 %global flavors_to_build x86_64
 %endif
 
@@ -93,7 +91,7 @@ done
 # mark modules executable so that strip-to-file can strip them
 find %{buildroot} -type f -name \*.ko -exec %{__chmod} u+x \{\} \;
 
-%if 0%{?el8}
+%if ! 0%{?el7}
 %files
 /lib/modules
 

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -275,3 +275,10 @@ endif
 ifneq (,$(shell grep 'const struct list_head ., const struct list_head .' include/linux/list_sort.h))
 ccflags-y += -DKC_LIST_CMP_CONST_ARG_LIST_HEAD
 endif
+
+# v5.7-523-g88dca4ca5a93
+#
+# The pgprot argument to vmalloc is always PAGE_KERNEL, so it is removed.
+ifneq (,$(shell grep 'extern void .__vmalloc.unsigned long size, gfp_t gfp_mask, pgprot_t prot' include/linux/vmalloc.h))
+ccflags-y += -DKC_VMALLOC_PGPROT_T
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -330,3 +330,35 @@ endif
 ifneq (,$(shell grep 'ssize_t generic_perform_write.struct kiocb ., struct iov_iter' include/linux/fs.h))
 ccflags-y += -DKC_GENERIC_PERFORM_WRITE_KIOCB_IOV_ITER
 endif
+
+#
+# v5.7-rc6-2496-g76ee0785f42a
+#
+# net: add sock_set_sndtimeo
+ifneq (,$(shell grep 'void sock_set_sndtimeo.struct sock' include/net/sock.h))
+ccflags-y += -DKC_SOCK_SET_SNDTIMEO
+endif
+
+#
+# v5.8-rc4-1931-gba423fdaa589
+#
+# setsockopt functions are now passed a sockptr_t value instead of char*
+ifneq (,$(shell grep -s 'include .linux/sockptr.h.' include/linux/net.h))
+ccflags-y += -DKC_SETSOCKOPT_SOCKPTR_T
+endif
+
+#
+# v5.7-rc6-2507-g71c48eb81c9e
+#
+# Adds a bunch of low level TCP sock parameter functions that we want to use.
+ifneq (,$(shell grep 'int tcp_sock_set_keepintvl' include/linux/tcp.h))
+ccflags-y += -DKC_HAVE_TCP_SET_SOCKFN
+endif
+
+#
+# v4.16-rc3-13-ga84d1169164b
+#
+# Fixes y2038 issues with struct timeval.
+ifneq (,$(shell grep -s '^struct __kernel_old_timeval .' include/uapi/linux/time_types.h))
+ccflags-y += -DKC_KERNEL_OLD_TIMEVAL_STRUCT
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -386,3 +386,11 @@ endif
 ifneq (,$(shell grep 'int mpage_read_folio.struct folio .folio' include/linux/mpage.h))
 ccflags-y += -DKC_MPAGE_READ_FOLIO
 endif
+
+#
+# v5.18-rc5-219-gb3992d1e2ebc
+#
+# block_write_begin() no longer is being passed aop_flags
+ifneq (,$(shell grep -C1 'int block_write_begin' include/linux/buffer_head.h | tail -n 2 | grep 'unsigned flags'))
+ccflags-y += -DKC_BLOCK_WRITE_BEGIN_AOP_FLAGS
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -378,3 +378,11 @@ endif
 ifneq (,$(shell grep 'int __printf.*register_shrinker.struct shrinker .shrinker,' include/linux/shrinker.h))
 ccflags-y += -DKC_SHRINKER_NAME
 endif
+
+#
+# v5.18-rc5-246-gf132ab7d3ab0
+#
+# mpage_readpage() is now replaced with mpage_read_folio.
+ifneq (,$(shell grep 'int mpage_read_folio.struct folio .folio' include/linux/mpage.h))
+ccflags-y += -DKC_MPAGE_READ_FOLIO
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -322,3 +322,11 @@ endif
 ifneq (,$(shell grep -s 'int fiemap_prep.struct inode' include/linux/fiemap.h))
 ccflags-y += -DKC_FIEMAP_PREP
 endif
+
+#
+# v5.17-13043-g800ba29547e1
+#
+# generic_perform_write args use kiocb for passing filp and pos
+ifneq (,$(shell grep 'ssize_t generic_perform_write.struct kiocb ., struct iov_iter' include/linux/fs.h))
+ccflags-y += -DKC_GENERIC_PERFORM_WRITE_KIOCB_IOV_ITER
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -362,3 +362,11 @@ endif
 ifneq (,$(shell grep -s '^struct __kernel_old_timeval .' include/uapi/linux/time_types.h))
 ccflags-y += -DKC_KERNEL_OLD_TIMEVAL_STRUCT
 endif
+
+#
+# v4.19-rc8-2267-g00e23707442a
+#
+# iov_iter type is expanded to contain pipe, bvec and other types.
+ifneq (,$(shell grep 'static inline bool iter_is_iovec' include/linux/uio.h))
+ccflags-y += -DKC_ITER_IS_IOVEC
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -267,3 +267,11 @@ endif
 ifneq (,$(shell grep 'typedef __u32 __bitwise blk_opf_t' include/linux/blk_types.h))
 ccflags-y += -DKC_HAVE_BLK_OPF_T=1
 endif
+
+#
+# v5.12-rc6-9-g4f0f586bf0c8
+#
+# list_sort cmp function takes const list_head args
+ifneq (,$(shell grep 'const struct list_head ., const struct list_head .' include/linux/list_sort.h))
+ccflags-y += -DKC_LIST_CMP_CONST_ARG_LIST_HEAD
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -258,3 +258,11 @@ endif
 ifneq (,$(shell grep 'static inline const char .xattr_prefix' include/linux/xattr.h))
 ccflags-y += -DKC_XATTR_HANDLER_NAME=1
 endif
+
+#
+# v5.19-rc4-96-g342a72a33407
+#
+# Adds `typedef __u32 __bitwise blk_opf_t` to aid flag checking
+ifneq (,$(shell grep 'typedef __u32 __bitwise blk_opf_t' include/linux/blk_types.h))
+ccflags-y += -DKC_HAVE_BLK_OPF_T=1
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -370,3 +370,11 @@ endif
 ifneq (,$(shell grep 'static inline bool iter_is_iovec' include/linux/uio.h))
 ccflags-y += -DKC_ITER_IS_IOVEC
 endif
+
+#
+# v5.19-rc4-52-ge33c267ab70d
+#
+# register_shrinker now requires a name, used for debug stats etc.
+ifneq (,$(shell grep 'int __printf.*register_shrinker.struct shrinker .shrinker,' include/linux/shrinker.h))
+ccflags-y += -DKC_SHRINKER_NAME
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -394,3 +394,13 @@ endif
 ifneq (,$(shell grep -C1 'int block_write_begin' include/linux/buffer_head.h | tail -n 2 | grep 'unsigned flags'))
 ccflags-y += -DKC_BLOCK_WRITE_BEGIN_AOP_FLAGS
 endif
+
+#
+# v6.0-rc6-9-g863f144f12ad
+#
+# the .tmpfile() vfs method calling convention changed and now a struct
+# file* is passed to this metiond instead of a dentry. The function also
+# should open the created file and call finish_open_simple() before returning.
+ifneq (,$(shell grep 'extern void d_tmpfile.struct dentry' include/linux/dcache.h))
+ccflags-y += -DKC_D_TMPFILE_DENTRY
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -412,3 +412,12 @@ endif
 ifneq (,$(shell grep 'typedef unsigned int __bitwise blk_mode_t' include/linux/blkdev.h))
 ccflags-y += -DKC_HAVE_BLK_MODE_T
 endif
+
+#
+# v6.4-rc2-186-g2736e8eeb0cc
+#
+# Reworks FMODE_EXCL kludge and instead modifies the blkdev_put() call to pass in
+# the (exclusive) holder to implement FMODE_EXCL handling.
+ifneq (,$(shell grep 'blkdev_put.struct block_device .bdev, void .holder' include/linux/blkdev.h))
+ccflags-y += -DKC_BLKDEV_PUT_HOLDER_ARG
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -78,8 +78,9 @@ endif
 # v4.8-rc1-29-g31051c85b5e2
 #
 # inode_change_ok() removed - replace with setattr_prepare()
+# v5.11-rc4-7-g2f221d6f7b88 removes extern attribute
 #
-ifneq (,$(shell grep 'extern int setattr_prepare' include/linux/fs.h))
+ifneq (,$(shell grep 'int setattr_prepare' include/linux/fs.h))
 ccflags-y += -DKC_SETATTR_PREPARE
 endif
 

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -283,6 +283,30 @@ ifneq (,$(shell grep 'extern void .__vmalloc.unsigned long size, gfp_t gfp_mask,
 ccflags-y += -DKC_VMALLOC_PGPROT_T
 endif
 
+# v6.2-rc1-18-g01beba7957a2
+#
+# fs: port inode_owner_or_capable() to mnt_idmap
+ifneq (,$(shell grep 'bool inode_owner_or_capable.struct user_namespace .mnt_userns' include/linux/fs.h))
+ccflags-y += -DKC_INODE_OWNER_OR_CAPABLE_USERNS
+endif
+
+#
+# v5.11-rc4-5-g47291baa8ddf
+#
+# namei: make permission helpers idmapped mount aware
+ifneq (,$(shell grep 'int inode_permission.struct user_namespace' include/linux/fs.h))
+ccflags-y += -DKC_INODE_PERMISSION_USERNS
+endif
+
+#
+# v5.11-rc4-24-g549c7297717c
+#
+# fs: make helpers idmap mount aware
+# Enlarges the VFS API methods to include user namespace argument.
+ifneq (,$(shell grep 'int ..mknod. .struct user_namespace' include/linux/fs.h))
+ccflags-y += -DKC_VFS_METHOD_USER_NAMESPACE_ARG
+endif
+
 #
 # v5.17-rc2-21-g07888c665b40
 #

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -404,3 +404,11 @@ endif
 ifneq (,$(shell grep 'extern void d_tmpfile.struct dentry' include/linux/dcache.h))
 ccflags-y += -DKC_D_TMPFILE_DENTRY
 endif
+
+#
+# v6.4-rc2-201-g0733ad800291
+#
+# New blk_mode_t replaces abuse of fmode_t
+ifneq (,$(shell grep 'typedef unsigned int __bitwise blk_mode_t' include/linux/blkdev.h))
+ccflags-y += -DKC_HAVE_BLK_MODE_T
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -282,3 +282,11 @@ endif
 ifneq (,$(shell grep 'extern void .__vmalloc.unsigned long size, gfp_t gfp_mask, pgprot_t prot' include/linux/vmalloc.h))
 ccflags-y += -DKC_VMALLOC_PGPROT_T
 endif
+
+#
+# v5.17-rc2-21-g07888c665b40
+#
+# Detect new style bio_alloc - pass bdev and opf.
+ifneq (,$(shell grep 'struct bio .bio_alloc.struct block_device .bdev' include/linux/bio.h))
+ccflags-y += -DKC_BIO_ALLOC_DEV_OPF_ARGS
+endif

--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -314,3 +314,11 @@ endif
 ifneq (,$(shell grep 'struct bio .bio_alloc.struct block_device .bdev' include/linux/bio.h))
 ccflags-y += -DKC_BIO_ALLOC_DEV_OPF_ARGS
 endif
+
+#
+# v5.7-rc4-53-gcddf8a2c4a82
+#
+# fiemap_prep() replaces fiemap_check_flags()
+ifneq (,$(shell grep -s 'int fiemap_prep.struct inode' include/linux/fiemap.h))
+ccflags-y += -DKC_FIEMAP_PREP
+endif

--- a/kmod/src/acl.c
+++ b/kmod/src/acl.c
@@ -269,7 +269,7 @@ int scoutfs_acl_set_xattr(struct dentry *dentry, const char *name, const void *v
 	struct posix_acl *acl = NULL;
 	int ret;
 
-	if (!inode_owner_or_capable(dentry->d_inode))
+	if (!inode_owner_or_capable(KC_VFS_INIT_NS dentry->d_inode))
 		return -EPERM;
 
 	if (!IS_POSIXACL(dentry->d_inode))

--- a/kmod/src/acl.c
+++ b/kmod/src/acl.c
@@ -155,7 +155,8 @@ int scoutfs_set_acl_locked(struct inode *inode, struct posix_acl *acl, int type,
 	switch (type) {
 	case ACL_TYPE_ACCESS:
 		if (acl) {
-			ret = posix_acl_update_mode(inode, &new_mode, &acl);
+			ret = posix_acl_update_mode(KC_VFS_INIT_NS
+						    inode, &new_mode, &acl);
 			if (ret < 0)
 				goto out;
 			set_mode = true;

--- a/kmod/src/acl.c
+++ b/kmod/src/acl.c
@@ -257,7 +257,9 @@ int scoutfs_acl_get_xattr(struct dentry *dentry, const char *name, void *value, 
 }
 
 #ifdef KC_XATTR_STRUCT_XATTR_HANDLER
-int scoutfs_acl_set_xattr(const struct xattr_handler *handler, struct dentry *dentry,
+int scoutfs_acl_set_xattr(const struct xattr_handler *handler,
+			  KC_VFS_NS_DEF
+			  struct dentry *dentry,
 			  struct inode *inode, const char *name, const void *value,
 			  size_t size, int flags)
 {

--- a/kmod/src/acl.h
+++ b/kmod/src/acl.h
@@ -10,7 +10,9 @@ int scoutfs_set_acl_locked(struct inode *inode, struct posix_acl *acl, int type,
 int scoutfs_acl_get_xattr(const struct xattr_handler *, struct dentry *dentry,
 			  struct inode *inode, const char *name, void *value,
 			  size_t size);
-int scoutfs_acl_set_xattr(const struct xattr_handler *, struct dentry *dentry,
+int scoutfs_acl_set_xattr(const struct xattr_handler *,
+			  KC_VFS_NS_DEF
+			  struct dentry *dentry,
 			  struct inode *inode, const char *name, const void *value,
 			  size_t size, int flags);
 #else

--- a/kmod/src/alloc.c
+++ b/kmod/src/alloc.c
@@ -14,6 +14,7 @@
 #include <linux/module.h>
 #include <linux/fs.h>
 #include <linux/slab.h>
+#include <linux/blkdev.h>
 #include <linux/sort.h>
 #include <linux/random.h>
 

--- a/kmod/src/block.c
+++ b/kmod/src/block.c
@@ -437,7 +437,7 @@ static void block_remove_all(struct super_block *sb)
  * possible.  Final freeing, verifying checksums, and unlinking errored
  * blocks are all done by future users of the blocks.
  */
-static void block_end_io(struct super_block *sb, unsigned int opf,
+static void block_end_io(struct super_block *sb, blk_opf_t opf,
 			 struct block_private *bp, int err)
 {
 	DECLARE_BLOCK_INFO(sb, binf);
@@ -477,7 +477,7 @@ static void KC_DECLARE_BIO_END_IO(block_bio_end_io, struct bio *bio)
  * Kick off IO for a single block.
  */
 static int block_submit_bio(struct super_block *sb, struct block_private *bp,
-			    unsigned int opf)
+			    blk_opf_t opf)
 {
 	struct scoutfs_sb_info *sbi = SCOUTFS_SB(sb);
 	struct bio *bio = NULL;
@@ -1196,7 +1196,7 @@ static void KC_DECLARE_BIO_END_IO(sm_block_bio_end_io, struct bio *bio)
  * only layer that sees the full block buffer so we pass the calculated
  * crc to the caller for them to check in their context.
  */
-static int sm_block_io(struct super_block *sb, struct block_device *bdev, unsigned int opf,
+static int sm_block_io(struct super_block *sb, struct block_device *bdev, blk_opf_t opf,
 		       u64 blkno, struct scoutfs_block_header *hdr, size_t len, __le32 *blk_crc)
 {
 	struct scoutfs_block_header *pg_hdr;

--- a/kmod/src/block.c
+++ b/kmod/src/block.c
@@ -120,8 +120,7 @@ do {												\
 
 static __le32 block_calc_crc(struct scoutfs_block_header *hdr, u32 size)
 {
-	int off = offsetof(struct scoutfs_block_header, crc) +
-		  FIELD_SIZEOF(struct scoutfs_block_header, crc);
+	int off = offsetofend(struct scoutfs_block_header, crc);
 	u32 calc = crc32c(~0, (char *)hdr + off, size - off);
 
 	return cpu_to_le32(calc);

--- a/kmod/src/block.c
+++ b/kmod/src/block.c
@@ -1293,7 +1293,7 @@ int scoutfs_block_setup(struct super_block *sb)
 	init_waitqueue_head(&binf->waitq);
 	KC_INIT_SHRINKER_FUNCS(&binf->shrinker, block_count_objects,
 			       block_scan_objects);
-	KC_REGISTER_SHRINKER(&binf->shrinker);
+	KC_REGISTER_SHRINKER(&binf->shrinker, "scoutfs-block_info:" SCSBF, SCSB_ARGS(sb));
 	INIT_WORK(&binf->free_work, block_free_work);
 	init_llist_head(&binf->free_llist);
 

--- a/kmod/src/block.c
+++ b/kmod/src/block.c
@@ -158,7 +158,7 @@ static struct block_private *block_alloc(struct super_block *sb, u64 blkno)
 		 */
 		lockdep_off();
 		nofs_flags = memalloc_nofs_save();
-		bp->virt = __vmalloc(SCOUTFS_BLOCK_LG_SIZE, GFP_NOFS | __GFP_HIGHMEM, PAGE_KERNEL);
+		bp->virt = kc__vmalloc(SCOUTFS_BLOCK_LG_SIZE, GFP_NOFS | __GFP_HIGHMEM);
 		memalloc_nofs_restore(nofs_flags);
 		lockdep_on();
 

--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -1837,41 +1837,6 @@ int scoutfs_data_wait_check_iov(struct inode *inode, const struct iovec *iov,
 	return ret;
 }
 
-int scoutfs_data_wait_check_iter(struct inode *inode, loff_t pos, struct iov_iter *iter,
-				 u8 sef, u8 op, struct scoutfs_data_wait *dw,
-				 struct scoutfs_lock *lock)
-{
-	size_t count = iov_iter_count(iter);
-	size_t off = iter->iov_offset;
-	const struct iovec *iov;
-	size_t len;
-	int ret = 0;
-
-	if (!iter_is_iovec(iter))
-		return scoutfs_data_wait_check(inode, pos, count,
-					       sef, op, dw, lock);
-
-	for (iov = iter->iov; count > 0; iov++) {
-		len = iov->iov_len - off;
-		if (len == 0)
-			continue;
-
-		/* aren't we waiting on too much data here ? */
-		ret = scoutfs_data_wait_check(inode, pos, len,
-					      sef, op, dw, lock);
-
-		if (ret != 0)
-			break;
-
-
-		pos += len;
-		count -= len;
-		off = 0;
-	}
-
-	return ret;
-}
-
 int scoutfs_data_wait(struct inode *inode, struct scoutfs_data_wait *dw)
 {
 	DECLARE_DATA_WAIT_ROOT(inode->i_sb, rt);

--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -841,7 +841,10 @@ struct write_begin_data {
 
 static int scoutfs_write_begin(struct file *file,
 			       struct address_space *mapping, loff_t pos,
-			       unsigned len, unsigned flags,
+			       unsigned len,
+#ifdef KC_BLOCK_WRITE_BEGIN_AOP_FLAGS
+			       unsigned flags,
+#endif
 			       struct page **pagep, void **fsdata)
 {
 	struct inode *inode = mapping->host;
@@ -876,13 +879,18 @@ retry:
 	if (ret < 0)
 		goto out;
 
+#ifdef KC_BLOCK_WRITE_BEGIN_AOP_FLAGS
 	/* can't re-enter fs, have trans */
 	flags |= AOP_FLAG_NOFS;
+#endif
 
 	/* generic write_end updates i_size and calls dirty_inode */
 	ret = scoutfs_dirty_inode_item(inode, wbd->lock) ?:
-	      block_write_begin(mapping, pos, len, flags, pagep,
-				scoutfs_get_block_write);
+	      block_write_begin(mapping, pos, len,
+#ifdef KC_BLOCK_WRITE_BEGIN_AOP_FLAGS
+				flags,
+#endif
+				pagep, scoutfs_get_block_write);
 	if (ret < 0) {
 		scoutfs_release_trans(sb);
 		scoutfs_inode_index_unlock(sb, &wbd->ind_locks);

--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -1311,8 +1311,8 @@ int scoutfs_data_move_blocks(struct inode *from, u64 from_off,
 		goto out;
 	}
 
-	ret = inode_permission(from, MAY_WRITE) ?:
-	      inode_permission(to, MAY_WRITE);
+	ret = inode_permission(KC_VFS_INIT_NS from, MAY_WRITE) ?:
+	      inode_permission(KC_VFS_INIT_NS to, MAY_WRITE);
 	if (ret < 0)
 		goto out;
 

--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -1550,7 +1550,7 @@ int scoutfs_data_fiemap(struct inode *inode, struct fiemap_extent_info *fieinfo,
 		goto out;
 	}
 
-	ret = fiemap_check_flags(fieinfo, FIEMAP_FLAG_SYNC);
+	ret = fiemap_prep(inode, fieinfo, start, &len, FIEMAP_FLAG_SYNC);
 	if (ret)
 		goto out;
 

--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -1953,6 +1953,8 @@ const struct file_operations scoutfs_file_fops = {
 #else
 	.read_iter	= scoutfs_file_read_iter,
 	.write_iter	= scoutfs_file_write_iter,
+	.splice_read	= generic_file_splice_read,
+	.splice_write	= iter_file_splice_write,
 #endif
 	.unlocked_ioctl	= scoutfs_ioctl,
 	.fsync		= scoutfs_file_fsync,

--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -1818,6 +1818,10 @@ int scoutfs_data_wait_check_iter(struct inode *inode, loff_t pos, struct iov_ite
 	size_t len;
 	int ret = 0;
 
+	if (!iter_is_iovec(iter))
+		return scoutfs_data_wait_check(inode, pos, count,
+					       sef, op, dw, lock);
+
 	for (iov = iter->iov; count > 0; iov++) {
 		len = iov->iov_len - off;
 		if (len == 0)

--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -20,6 +20,7 @@
 #include <linux/hash.h>
 #include <linux/log2.h>
 #include <linux/falloc.h>
+#include <linux/fiemap.h>
 #include <linux/writeback.h>
 
 #include "format.h"

--- a/kmod/src/data.h
+++ b/kmod/src/data.h
@@ -65,9 +65,6 @@ int scoutfs_data_wait_check_iov(struct inode *inode, const struct iovec *iov,
 				unsigned long nr_segs, loff_t pos, u8 sef,
 				u8 op, struct scoutfs_data_wait *ow,
 				struct scoutfs_lock *lock);
-int scoutfs_data_wait_check_iter(struct inode *inode, loff_t pos, struct iov_iter *iter,
-				 u8 sef, u8 op, struct scoutfs_data_wait *ow,
-				 struct scoutfs_lock *lock);
 bool scoutfs_data_wait_found(struct scoutfs_data_wait *ow);
 int scoutfs_data_wait(struct inode *inode,
 			      struct scoutfs_data_wait *ow);

--- a/kmod/src/dir.c
+++ b/kmod/src/dir.c
@@ -696,8 +696,9 @@ out_unlock:
 	return inode;
 }
 
-static int scoutfs_mknod(struct inode *dir, struct dentry *dentry, umode_t mode,
-		       dev_t rdev)
+static int scoutfs_mknod(KC_VFS_NS_DEF
+			 struct inode *dir,
+			 struct dentry *dentry, umode_t mode, dev_t rdev)
 {
 	struct super_block *sb = dir->i_sb;
 	struct inode *inode = NULL;
@@ -766,15 +767,20 @@ out:
 }
 
 /* XXX hmm, do something with excl? */
-static int scoutfs_create(struct inode *dir, struct dentry *dentry,
-			  umode_t mode, bool excl)
+static int scoutfs_create(KC_VFS_NS_DEF
+			  struct inode *dir,
+			  struct dentry *dentry, umode_t mode, bool excl)
 {
-	return scoutfs_mknod(dir, dentry, mode | S_IFREG, 0);
+	return scoutfs_mknod(KC_VFS_NS
+			     dir, dentry, mode | S_IFREG, 0);
 }
 
-static int scoutfs_mkdir(struct inode *dir, struct dentry *dentry, umode_t mode)
+static int scoutfs_mkdir(KC_VFS_NS_DEF
+			 struct inode *dir,
+			 struct dentry *dentry, umode_t mode)
 {
-	return scoutfs_mknod(dir, dentry, mode | S_IFDIR, 0);
+	return scoutfs_mknod(KC_VFS_NS
+			     dir, dentry, mode | S_IFDIR, 0);
 }
 
 static int scoutfs_link(struct dentry *old_dentry,
@@ -1165,7 +1171,8 @@ static const char *scoutfs_get_link(struct dentry *dentry, struct inode *inode, 
  * Symlink target paths can be annoyingly large.  We store relatively
  * rare large paths in multiple items.
  */
-static int scoutfs_symlink(struct inode *dir, struct dentry *dentry,
+static int scoutfs_symlink(KC_VFS_NS_DEF
+			   struct inode *dir, struct dentry *dentry,
 			   const char *symname)
 {
 	struct super_block *sb = dir->i_sb;
@@ -1552,7 +1559,8 @@ static int verify_ancestors(struct super_block *sb, u64 p1, u64 p2,
  * from using parent/child locking orders as two groups can have both
  * parent and child relationships to each other.
  */
-static int scoutfs_rename_common(struct inode *old_dir,
+static int scoutfs_rename_common(KC_VFS_NS_DEF
+				 struct inode *old_dir,
 				 struct dentry *old_dentry, struct inode *new_dir,
 				 struct dentry *new_dentry, unsigned int flags)
 {
@@ -1825,18 +1833,21 @@ static int scoutfs_rename(struct inode *old_dir,
 			  struct dentry *old_dentry, struct inode *new_dir,
 			  struct dentry *new_dentry)
 {
-	return scoutfs_rename_common(old_dir, old_dentry, new_dir, new_dentry, 0);
+	return scoutfs_rename_common(KC_VFS_INIT_NS
+				     old_dir, old_dentry, new_dir, new_dentry, 0);
 }
 #endif
 
-static int scoutfs_rename2(struct inode *old_dir,
+static int scoutfs_rename2(KC_VFS_NS_DEF
+			  struct inode *old_dir,
 			  struct dentry *old_dentry, struct inode *new_dir,
 			  struct dentry *new_dentry, unsigned int flags)
 {
 	if (flags & ~RENAME_NOREPLACE)
 		return -EINVAL;
 
-	return scoutfs_rename_common(old_dir, old_dentry, new_dir, new_dentry, flags);
+	return scoutfs_rename_common(KC_VFS_NS
+				     old_dir, old_dentry, new_dir, new_dentry, flags);
 }
 
 #ifdef KC_FMODE_KABI_ITERATE
@@ -1848,7 +1859,8 @@ static int scoutfs_dir_open(struct inode *inode, struct file *file)
 }
 #endif
 
-static int scoutfs_tmpfile(struct inode *dir, struct dentry *dentry, umode_t mode)
+static int scoutfs_tmpfile(KC_VFS_NS_DEF
+			   struct inode *dir, struct dentry *dentry, umode_t mode)
 {
 	struct super_block *sb = dir->i_sb;
 	struct inode *inode = NULL;

--- a/kmod/src/fence.c
+++ b/kmod/src/fence.c
@@ -105,12 +105,12 @@ static ssize_t elapsed_secs_show(struct kobject *kobj,
 {
 	DECLARE_FENCE_FROM_KOBJ(fence, kobj);
 	ktime_t now = ktime_get();
-	struct timeval tv = { 0, };
+	ktime_t t = ns_to_ktime(0);
 
 	if (ktime_after(now, fence->start_kt))
-		tv = ktime_to_timeval(ktime_sub(now, fence->start_kt));
+		t = ktime_sub(now, fence->start_kt);
 
-	return snprintf(buf, PAGE_SIZE, "%llu", (long long)tv.tv_sec);
+	return snprintf(buf, PAGE_SIZE, "%llu", (long long)ktime_divns(t, NSEC_PER_SEC));
 }
 SCOUTFS_ATTR_RO(elapsed_secs);
 

--- a/kmod/src/file.c
+++ b/kmod/src/file.c
@@ -255,7 +255,8 @@ out:
 }
 #endif
 
-int scoutfs_permission(struct inode *inode, int mask)
+int scoutfs_permission(KC_VFS_NS_DEF
+		       struct inode *inode, int mask)
 {
 	struct super_block *sb = inode->i_sb;
 	struct scoutfs_lock *inode_lock = NULL;
@@ -269,7 +270,8 @@ int scoutfs_permission(struct inode *inode, int mask)
 	if (ret)
 		return ret;
 
-	ret = generic_permission(inode, mask);
+	ret = generic_permission(KC_VFS_INIT_NS
+				 inode, mask);
 
 	scoutfs_unlock(sb, inode_lock, SCOUTFS_LOCK_READ);
 

--- a/kmod/src/file.c
+++ b/kmod/src/file.c
@@ -171,10 +171,8 @@ retry:
 		goto out;
 
 	if (scoutfs_per_task_add_excl(&si->pt_data_lock, &pt_ent, scoutfs_inode_lock)) {
-		ret = scoutfs_data_wait_check_iter(inode, iocb->ki_pos, to,
-						   SEF_OFFLINE,
-						   SCOUTFS_IOC_DWO_READ,
-						   &dw, scoutfs_inode_lock);
+		ret = scoutfs_data_wait_check(inode, iocb->ki_pos, iov_iter_count(to), SEF_OFFLINE,
+					      SCOUTFS_IOC_DWO_READ, &dw, scoutfs_inode_lock);
 		if (ret != 0)
 			goto out;
 	} else {

--- a/kmod/src/file.c
+++ b/kmod/src/file.c
@@ -224,10 +224,8 @@ retry:
 
 	if (scoutfs_per_task_add_excl(&si->pt_data_lock, &pt_ent, scoutfs_inode_lock)) {
 		/* data_version is per inode, whole file must be online */
-		ret = scoutfs_data_wait_check_iter(inode, iocb->ki_pos, from,
-						   SEF_OFFLINE,
-						   SCOUTFS_IOC_DWO_WRITE,
-						   &dw, scoutfs_inode_lock);
+		ret = scoutfs_data_wait_check(inode, 0, i_size_read(inode), SEF_OFFLINE,
+					      SCOUTFS_IOC_DWO_WRITE, &dw, scoutfs_inode_lock);
 		if (ret != 0)
 			goto out;
 	}

--- a/kmod/src/file.c
+++ b/kmod/src/file.c
@@ -205,8 +205,7 @@ ssize_t scoutfs_file_write_iter(struct kiocb *iocb, struct iov_iter *from)
 	struct scoutfs_lock *scoutfs_inode_lock = NULL;
 	SCOUTFS_DECLARE_PER_TASK_ENTRY(pt_ent);
 	DECLARE_DATA_WAIT(dw);
-	int ret;
-	int written;
+	ssize_t ret;
 
 retry:
 	inode_lock(inode);
@@ -235,7 +234,7 @@ retry:
 
 	/* XXX: remove SUID bit */
 
-	written = __generic_file_write_iter(iocb, from);
+	ret = __generic_file_write_iter(iocb, from);
 
 out:
 	scoutfs_per_task_del(&si->pt_data_lock, &pt_ent);
@@ -248,10 +247,10 @@ out:
 			goto retry;
 	}
 
-	if (ret > 0 || ret == -EIOCBQUEUED)
-		ret = generic_write_sync(iocb, written);
+	if (ret > 0)
+		ret = generic_write_sync(iocb, ret);
 
-	return written ? written : ret;
+	return ret;
 }
 #endif
 

--- a/kmod/src/file.h
+++ b/kmod/src/file.h
@@ -10,7 +10,8 @@ ssize_t scoutfs_file_aio_write(struct kiocb *iocb, const struct iovec *iov,
 ssize_t scoutfs_file_read_iter(struct kiocb *, struct iov_iter *);
 ssize_t scoutfs_file_write_iter(struct kiocb *, struct iov_iter *);
 #endif
-int scoutfs_permission(struct inode *inode, int mask);
+int scoutfs_permission(KC_VFS_NS_DEF
+		       struct inode *inode, int mask);
 loff_t scoutfs_file_llseek(struct file *file, loff_t offset, int whence);
 
 #endif	/* _SCOUTFS_FILE_H_ */

--- a/kmod/src/inode.c
+++ b/kmod/src/inode.c
@@ -354,7 +354,8 @@ int scoutfs_getattr(struct vfsmount *mnt, struct dentry *dentry,
 {
 	struct inode *inode = dentry->d_inode;
 #else
-int scoutfs_getattr(const struct path *path, struct kstat *stat,
+int scoutfs_getattr(KC_VFS_NS_DEF
+		    const struct path *path, struct kstat *stat,
 		    u32 request_mask, unsigned int query_flags)
 {
 	struct inode *inode = d_inode(path->dentry);
@@ -366,7 +367,8 @@ int scoutfs_getattr(const struct path *path, struct kstat *stat,
 	ret = scoutfs_lock_inode(sb, SCOUTFS_LOCK_READ,
 				 SCOUTFS_LKF_REFRESH_INODE, inode, &lock);
 	if (ret == 0) {
-		generic_fillattr(inode, stat);
+		generic_fillattr(KC_VFS_INIT_NS
+				 inode, stat);
 		scoutfs_unlock(sb, lock, SCOUTFS_LOCK_READ);
 	}
 	return ret;
@@ -464,7 +466,8 @@ int scoutfs_complete_truncate(struct inode *inode, struct scoutfs_lock *lock)
  * re-acquire it.  Ideally we'd fix this so that we can acquire the lock
  * instead of the caller.
  */
-int scoutfs_setattr(struct dentry *dentry, struct iattr *attr)
+int scoutfs_setattr(KC_VFS_NS_DEF
+		    struct dentry *dentry, struct iattr *attr)
 {
 	struct inode *inode = dentry->d_inode;
 	struct super_block *sb = inode->i_sb;
@@ -482,7 +485,8 @@ retry:
 				 SCOUTFS_LKF_REFRESH_INODE, inode, &lock);
 	if (ret)
 		return ret;
-	ret = setattr_prepare(dentry, attr);
+	ret = setattr_prepare(KC_VFS_INIT_NS
+			      dentry, attr);
 	if (ret)
 		goto out;
 
@@ -542,7 +546,8 @@ retry:
 	if (ret < 0)
 		goto release;
 
-	setattr_copy(inode, attr);
+	setattr_copy(KC_VFS_INIT_NS
+		     inode, attr);
 	inode_inc_iversion(inode);
 	scoutfs_update_inode_item(inode, lock, &ind_locks);
 
@@ -1487,7 +1492,8 @@ int scoutfs_new_inode(struct super_block *sb, struct inode *dir, umode_t mode, d
 	scoutfs_inode_set_data_seq(inode);
 
 	inode->i_ino = ino; /* XXX overflow */
-	inode_init_owner(inode, dir, mode);
+	inode_init_owner(KC_VFS_INIT_NS
+			 inode, dir, mode);
 	inode_set_bytes(inode, 0);
 	inode->i_mtime = inode->i_atime = inode->i_ctime = current_time(inode);
 	inode->i_rdev = rdev;

--- a/kmod/src/inode.c
+++ b/kmod/src/inode.c
@@ -911,10 +911,10 @@ static bool inode_has_index(umode_t mode, u8 type)
 	}
 }
 
-static int cmp_index_lock(void *priv, struct list_head *A, struct list_head *B)
+static int cmp_index_lock(void *priv, KC_LIST_CMP_CONST struct list_head *A, KC_LIST_CMP_CONST struct list_head *B)
 {
-	struct index_lock *a = list_entry(A, struct index_lock, head);
-	struct index_lock *b = list_entry(B, struct index_lock, head);
+	KC_LIST_CMP_CONST struct index_lock *a = list_entry(A, KC_LIST_CMP_CONST struct index_lock, head);
+	KC_LIST_CMP_CONST struct index_lock *b = list_entry(B, KC_LIST_CMP_CONST struct index_lock, head);
 
 	return ((int)a->type - (int)b->type) ?:
 	       scoutfs_cmp_u64s(a->major, b->major) ?:

--- a/kmod/src/inode.h
+++ b/kmod/src/inode.h
@@ -127,10 +127,12 @@ int scoutfs_inode_refresh(struct inode *inode, struct scoutfs_lock *lock);
 int scoutfs_getattr(struct vfsmount *mnt, struct dentry *dentry,
 		    struct kstat *stat);
 #else
-int scoutfs_getattr(const struct path *path, struct kstat *stat,
+int scoutfs_getattr(KC_VFS_NS_DEF
+		    const struct path *path, struct kstat *stat,
 		    u32 request_mask, unsigned int query_flags);
 #endif
-int scoutfs_setattr(struct dentry *dentry, struct iattr *attr);
+int scoutfs_setattr(KC_VFS_NS_DEF
+		    struct dentry *dentry, struct iattr *attr);
 
 int scoutfs_inode_orphan_create(struct super_block *sb, u64 ino, struct scoutfs_lock *lock,
 				struct scoutfs_lock *primary);

--- a/kmod/src/ioctl.c
+++ b/kmod/src/ioctl.c
@@ -720,7 +720,8 @@ static long scoutfs_ioc_listxattr_hidden(struct file *file, unsigned long arg)
 	int total = 0;
 	int ret;
 
-	ret = inode_permission(inode, MAY_READ);
+	ret = inode_permission(KC_VFS_INIT_NS
+			       inode, MAY_READ);
 	if (ret < 0)
 		goto out;
 

--- a/kmod/src/item.c
+++ b/kmod/src/item.c
@@ -2202,18 +2202,18 @@ u64 scoutfs_item_dirty_pages(struct super_block *sb)
 	return (u64)atomic_read(&cinf->dirty_pages);
 }
 
-static int cmp_pg_start(void *priv, struct list_head *A, struct list_head *B)
+static int cmp_pg_start(void *priv, KC_LIST_CMP_CONST struct list_head *A, KC_LIST_CMP_CONST struct list_head *B)
 {
-	struct cached_page *a = list_entry(A, struct cached_page, dirty_head);
-	struct cached_page *b = list_entry(B, struct cached_page, dirty_head);
+	KC_LIST_CMP_CONST struct cached_page *a = list_entry(A, KC_LIST_CMP_CONST struct cached_page, dirty_head);
+	KC_LIST_CMP_CONST struct cached_page *b = list_entry(B, KC_LIST_CMP_CONST struct cached_page, dirty_head);
 
 	return scoutfs_key_compare(&a->start, &b->start);
 }
 
-static int cmp_item_key(void *priv, struct list_head *A, struct list_head *B)
+static int cmp_item_key(void *priv, KC_LIST_CMP_CONST struct list_head *A, KC_LIST_CMP_CONST struct list_head *B)
 {
-	struct cached_item *a = list_entry(A, struct cached_item, dirty_head);
-	struct cached_item *b = list_entry(B, struct cached_item, dirty_head);
+	KC_LIST_CMP_CONST struct cached_item *a = list_entry(A, KC_LIST_CMP_CONST struct cached_item, dirty_head);
+	KC_LIST_CMP_CONST struct cached_item *b = list_entry(B, KC_LIST_CMP_CONST struct cached_item, dirty_head);
 
 	return scoutfs_key_compare(&a->key, &b->key);
 }

--- a/kmod/src/item.c
+++ b/kmod/src/item.c
@@ -2654,7 +2654,7 @@ int scoutfs_item_setup(struct super_block *sb)
 
 	KC_INIT_SHRINKER_FUNCS(&cinf->shrinker, item_cache_count_objects,
 			       item_cache_scan_objects);
-	KC_REGISTER_SHRINKER(&cinf->shrinker);
+	KC_REGISTER_SHRINKER(&cinf->shrinker, "scoutfs-item_cache:" SCSBF, SCSB_ARGS(sb));
 #ifdef KC_CPU_NOTIFIER
         cinf->notifier.notifier_call = item_cpu_callback;
         register_hotcpu_notifier(&cinf->notifier);

--- a/kmod/src/kernelcompat.c
+++ b/kmod/src/kernelcompat.c
@@ -67,12 +67,11 @@ kc_generic_file_buffered_write(struct kiocb *iocb, const struct iovec *iov,
 			       unsigned long nr_segs, loff_t pos, loff_t *ppos,
 			       size_t count, ssize_t written)
 {
-	struct file *file = iocb->ki_filp;
 	ssize_t status;
 	struct iov_iter i;
 
 	iov_iter_init(&i, WRITE, iov, nr_segs, count);
-	status = generic_perform_write(file, &i, pos);
+	status = kc_generic_perform_write(iocb, &i, pos);
 
 	if (likely(status >= 0)) {
 		written += status;

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -290,6 +290,16 @@ typedef unsigned int blk_opf_t;
 #define kc__vmalloc __vmalloc
 #endif
 
+#ifdef KC_VFS_METHOD_USER_NAMESPACE_ARG
+#define KC_VFS_NS_DEF struct user_namespace *mnt_user_ns,
+#define KC_VFS_NS mnt_user_ns,
+#define KC_VFS_INIT_NS &init_user_ns,
+#else
+#define KC_VFS_NS_DEF
+#define KC_VFS_NS
+#define KC_VFS_INIT_NS
+#endif
+
 #ifdef KC_BIO_ALLOC_DEV_OPF_ARGS
 #define kc_bio_alloc bio_alloc
 #else

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -434,4 +434,8 @@ static inline int kc_tcp_sock_set_nodelay(struct socket *sock)
 }
 #endif
 
+#ifndef KC_ITER_IS_IOVEC
+#define iter_is_iovec(iter) true
+#endif
+
 #endif

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -316,4 +316,8 @@ static inline struct bio *kc_bio_alloc(struct block_device *bdev, unsigned short
 }
 #endif
 
+#ifndef KC_FIEMAP_PREP
+#define fiemap_prep(inode, fieinfo, start, len, flags) fiemap_check_flags(fieinfo, flags)
+#endif
+
 #endif

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -284,4 +284,10 @@ typedef unsigned int blk_opf_t;
 #define KC_LIST_CMP_CONST
 #endif
 
+#ifdef KC_VMALLOC_PGPROT_T
+#define kc__vmalloc(size, gfp_mask) __vmalloc(size, gfp_mask, PAGE_KERNEL)
+#else
+#define kc__vmalloc __vmalloc
+#endif
+
 #endif

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -290,4 +290,20 @@ typedef unsigned int blk_opf_t;
 #define kc__vmalloc __vmalloc
 #endif
 
+#ifdef KC_BIO_ALLOC_DEV_OPF_ARGS
+#define kc_bio_alloc bio_alloc
+#else
+#include <linux/bio.h>
+static inline struct bio *kc_bio_alloc(struct block_device *bdev, unsigned short nr_vecs,
+				       blk_opf_t opf, gfp_t gfp_mask)
+{
+	struct bio *b = bio_alloc(gfp_mask, nr_vecs);
+	if (b) {
+		kc_bio_set_opf(b, opf);
+		bio_set_dev(b, bdev);
+	}
+	return b;
+}
+#endif
+
 #endif

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -197,7 +197,11 @@ struct timespec64 kc_current_time(struct inode *inode);
 } while (0)
 
 #define KC_SHRINKER_CONTAINER_OF(ptr, type) container_of(ptr, type, shrinker)
-#define KC_REGISTER_SHRINKER(ptr) (register_shrinker(ptr))
+#ifdef KC_SHRINKER_NAME
+#define KC_REGISTER_SHRINKER register_shrinker
+#else
+#define KC_REGISTER_SHRINKER(ptr, fmt, ...) (register_shrinker(ptr))
+#endif /* KC_SHRINKER_NAME */
 #define KC_UNREGISTER_SHRINKER(ptr) (unregister_shrinker(ptr))
 #define KC_SHRINKER_FN(ptr) (ptr)
 #else
@@ -224,7 +228,7 @@ struct kc_shrinker_wrapper {
 	_wrap->shrink.seeks = DEFAULT_SEEKS;			\
 } while (0)
 #define KC_SHRINKER_CONTAINER_OF(ptr, type) container_of(container_of(ptr, struct kc_shrinker_wrapper, shrink), type, shrinker)
-#define KC_REGISTER_SHRINKER(ptr) (register_shrinker(ptr.shrink))
+#define KC_REGISTER_SHRINKER(ptr, fmt, ...) (register_shrinker(ptr.shrink))
 #define KC_UNREGISTER_SHRINKER(ptr) (unregister_shrinker(ptr.shrink))
 #define KC_SHRINKER_FN(ptr) (ptr.shrink)
 

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -271,7 +271,20 @@ ssize_t kc_generic_file_buffered_write(struct kiocb *iocb, const struct iovec *i
                unsigned long nr_segs, loff_t pos, loff_t *ppos,
                size_t count, ssize_t written);
 #define generic_file_buffered_write kc_generic_file_buffered_write
+#ifdef KC_GENERIC_PERFORM_WRITE_KIOCB_IOV_ITER
+static inline int kc_generic_perform_write(struct kiocb *iocb, struct iov_iter *iter, loff_t pos)
+{
+	iocb->ki_pos = pos;
+	return generic_perform_write(iocb, iter);
+}
+#else
+static inline int kc_generic_perform_write(struct kiocb *iocb, struct iov_iter *iter, loff_t pos)
+{
+	struct file *file = iocb->ki_filp;
+	return generic_perform_write(file, iter, pos);
+}
 #endif
+#endif // KC_GENERIC_FILE_BUFFERED_WRITE
 
 #ifndef KC_HAVE_BLK_OPF_T
 /* typedef __u32 __bitwise blk_opf_t; */

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -278,4 +278,10 @@ ssize_t kc_generic_file_buffered_write(struct kiocb *iocb, const struct iovec *i
 typedef unsigned int blk_opf_t;
 #endif
 
+#ifdef KC_LIST_CMP_CONST_ARG_LIST_HEAD
+#define KC_LIST_CMP_CONST const
+#else
+#define KC_LIST_CMP_CONST
+#endif
+
 #endif

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -273,4 +273,9 @@ ssize_t kc_generic_file_buffered_write(struct kiocb *iocb, const struct iovec *i
 #define generic_file_buffered_write kc_generic_file_buffered_write
 #endif
 
+#ifndef KC_HAVE_BLK_OPF_T
+/* typedef __u32 __bitwise blk_opf_t; */
+typedef unsigned int blk_opf_t;
+#endif
+
 #endif

--- a/kmod/src/key.h
+++ b/kmod/src/key.h
@@ -125,8 +125,8 @@ static inline bool scoutfs_key_is_ones(struct scoutfs_key *key)
  * other alternatives across keys that first differ in any of the
  * values.  Say maybe 20% faster than memcmp.
  */
-static inline int scoutfs_key_compare(struct scoutfs_key *a,
-				      struct scoutfs_key *b)
+static inline int scoutfs_key_compare(const struct scoutfs_key *a,
+				      const struct scoutfs_key *b)
 {
 	return scoutfs_cmp(a->sk_zone, b->sk_zone) ?:
 	  scoutfs_cmp(le64_to_cpu(a->_sk_first), le64_to_cpu(b->_sk_first)) ?:
@@ -142,10 +142,10 @@ static inline int scoutfs_key_compare(struct scoutfs_key *a,
  *       1: a_start > b_end
  *  else 0: ranges overlap
  */
-static inline int scoutfs_key_compare_ranges(struct scoutfs_key *a_start,
-				             struct scoutfs_key *a_end,
-				             struct scoutfs_key *b_start,
-				             struct scoutfs_key *b_end)
+static inline int scoutfs_key_compare_ranges(const struct scoutfs_key *a_start,
+				             const struct scoutfs_key *a_end,
+				             const struct scoutfs_key *b_start,
+				             const struct scoutfs_key *b_end)
 {
 	return scoutfs_key_compare(a_end, b_start) < 0 ? -1 :
 	       scoutfs_key_compare(a_start, b_end) > 0 ? 1 :

--- a/kmod/src/lock.c
+++ b/kmod/src/lock.c
@@ -1708,7 +1708,7 @@ int scoutfs_lock_setup(struct super_block *sb)
 	linfo->lock_range_tree = RB_ROOT;
 	KC_INIT_SHRINKER_FUNCS(&linfo->shrinker, lock_count_objects,
 			       lock_scan_objects);
-	KC_REGISTER_SHRINKER(&linfo->shrinker);
+	KC_REGISTER_SHRINKER(&linfo->shrinker, "scoutfs-lock_info:" SCSBF, SCSB_ARGS(sb));
 	INIT_LIST_HEAD(&linfo->lru_list);
 	INIT_WORK(&linfo->inv_work, lock_invalidate_worker);
 	INIT_LIST_HEAD(&linfo->inv_list);

--- a/kmod/src/quorum.c
+++ b/kmod/src/quorum.c
@@ -1325,8 +1325,8 @@ int scoutfs_quorum_setup(struct super_block *sb)
 	qinf = kzalloc(sizeof(struct quorum_info), GFP_KERNEL);
 	super = kmalloc(sizeof(struct scoutfs_super_block), GFP_KERNEL);
 	if (qinf)
-		qinf->hb_delay = __vmalloc(HB_DELAY_NR * sizeof(struct count_recent),
-					   GFP_KERNEL | __GFP_ZERO, PAGE_KERNEL);
+		qinf->hb_delay = kc__vmalloc(HB_DELAY_NR * sizeof(struct count_recent),
+					   GFP_KERNEL | __GFP_ZERO);
 	if (!qinf || !super || !qinf->hb_delay) {
 		if (qinf)
 			vfree(qinf->hb_delay);

--- a/kmod/src/quorum.c
+++ b/kmod/src/quorum.c
@@ -486,7 +486,7 @@ static void set_quorum_block_event(struct super_block *sb, struct scoutfs_quorum
 	if (WARN_ON_ONCE(event < 0 || event >= SCOUTFS_QUORUM_EVENT_NR))
 		return;
 
-	getnstimeofday64(&ts);
+	ktime_get_ts64(&ts);
 	le64_add_cpu(&blk->write_nr, 1);
 
 	ev = &blk->events[event];

--- a/kmod/src/recov.c
+++ b/kmod/src/recov.c
@@ -76,10 +76,10 @@ static struct recov_pending *lookup_pending(struct recov_info *recinf, u64 rid, 
  * We keep the pending list sorted by rid so that we can iterate over
  * them.  The list should be small and shouldn't be used often.
  */
-static int cmp_pending_rid(void *priv, struct list_head *A, struct list_head *B)
+static int cmp_pending_rid(void *priv, KC_LIST_CMP_CONST struct list_head *A, KC_LIST_CMP_CONST struct list_head *B)
 {
-	struct recov_pending *a = list_entry(A, struct recov_pending, head);
-	struct recov_pending *b = list_entry(B, struct recov_pending, head);
+	KC_LIST_CMP_CONST struct recov_pending *a = list_entry(A, KC_LIST_CMP_CONST struct recov_pending, head);
+	KC_LIST_CMP_CONST struct recov_pending *b = list_entry(B, KC_LIST_CMP_CONST struct recov_pending, head);
 
 	return scoutfs_cmp_u64s(a->rid, b->rid);
 }

--- a/kmod/src/scoutfs_trace.h
+++ b/kmod/src/scoutfs_trace.h
@@ -24,7 +24,6 @@
 
 #include <linux/tracepoint.h>
 #include <linux/in.h>
-#include <linux/unaligned/access_ok.h>
 
 #include "key.h"
 #include "format.h"

--- a/kmod/src/server.c
+++ b/kmod/src/server.c
@@ -298,7 +298,7 @@ static void check_holder_budget(struct super_block *sb, struct server_info *serv
 {
 	static bool exceeded_once = false;
 	struct commit_hold *hold;
-	struct timespec ts;
+	struct timespec64 ts;
 	u32 avail_used;
 	u32 freed_used;
 	u32 avail_now;
@@ -330,7 +330,7 @@ static void check_holder_budget(struct super_block *sb, struct server_info *serv
 		    cusers->freed_before, freed_now);
 
 	list_for_each_entry(hold, &cusers->holding, entry) {
-		ts = ktime_to_timespec(hold->start);
+		ts = ktime_to_timespec64(hold->start);
 		scoutfs_err(sb, "exceeding hold start %llu.%09llu av %u fr %u",
 			    (u64)ts.tv_sec, (u64)ts.tv_nsec, hold->avail, hold->freed);
 		hold->exceeded = true;
@@ -445,7 +445,7 @@ static int server_apply_commit(struct super_block *sb, struct commit_hold *hold,
 {
 	DECLARE_SERVER_INFO(sb, server);
 	struct commit_users *cusers = &server->cusers;
-	struct timespec ts;
+	struct timespec64 ts;
 
 	spin_lock(&cusers->lock);
 
@@ -454,7 +454,7 @@ static int server_apply_commit(struct super_block *sb, struct commit_hold *hold,
 	check_holder_budget(sb, server, cusers);
 
 	if (hold->exceeded) {
-		ts = ktime_to_timespec(hold->start);
+		ts = ktime_to_timespec64(hold->start);
 		scoutfs_err(sb, "exceeding hold start %llu.%09llu stack:",
 			    (u64)ts.tv_sec, (u64)ts.tv_nsec);
 		dump_stack();

--- a/kmod/src/srch.c
+++ b/kmod/src/srch.c
@@ -18,6 +18,7 @@
 #include <linux/pagemap.h>
 #include <linux/vmalloc.h>
 #include <linux/sort.h>
+#include <asm/unaligned.h>
 
 #include "super.h"
 #include "format.h"

--- a/kmod/src/srch.c
+++ b/kmod/src/srch.c
@@ -1589,8 +1589,7 @@ static int kway_merge(struct super_block *sb,
 	nr_parents = max_t(unsigned long, 1, roundup_pow_of_two(nr) - 1);
 	/* root at [1] for easy sib/parent index calc, final pad for odd sib */
 	nr_nodes = 1 + nr_parents + nr + 1;
-	tnodes = __vmalloc(nr_nodes * sizeof(struct tourn_node),
-			   GFP_NOFS, PAGE_KERNEL);
+	tnodes = kc__vmalloc(nr_nodes * sizeof(struct tourn_node), GFP_NOFS);
 	if (!tnodes)
 		return -ENOMEM;
 

--- a/kmod/src/super.c
+++ b/kmod/src/super.c
@@ -158,7 +158,11 @@ static void scoutfs_metadev_close(struct super_block *sb)
 		 * from kill_sb->put_super.
 		 */
 		lockdep_off();
+#ifdef KC_BLKDEV_PUT_HOLDER_ARG
+		blkdev_put(sbi->meta_bdev, sb);
+#else
 		blkdev_put(sbi->meta_bdev, SCOUTFS_META_BDEV_MODE);
+#endif
 		lockdep_on();
 		sbi->meta_bdev = NULL;
 	}
@@ -519,7 +523,11 @@ static int scoutfs_fill_super(struct super_block *sb, void *data, int silent)
 		goto out;
 	}
 
+#ifdef KC_BLKDEV_PUT_HOLDER_ARG
+	meta_bdev = blkdev_get_by_path(opts.metadev_path, SCOUTFS_META_BDEV_MODE, sb, NULL);
+#else
 	meta_bdev = blkdev_get_by_path(opts.metadev_path, SCOUTFS_META_BDEV_MODE, sb);
+#endif
 	if (IS_ERR(meta_bdev)) {
 		scoutfs_err(sb, "could not open metadev: error %ld",
 			    PTR_ERR(meta_bdev));

--- a/kmod/src/super.h
+++ b/kmod/src/super.h
@@ -97,7 +97,11 @@ static inline bool SCOUTFS_IS_META_BDEV(struct scoutfs_super_block *super_block)
 	return !!(le64_to_cpu(super_block->flags) & SCOUTFS_FLAG_IS_META_BDEV);
 }
 
+#ifdef KC_HAVE_BLK_MODE_T
+#define SCOUTFS_META_BDEV_MODE (BLK_OPEN_READ | BLK_OPEN_WRITE | BLK_OPEN_EXCL)
+#else
 #define SCOUTFS_META_BDEV_MODE (FMODE_READ | FMODE_WRITE | FMODE_EXCL)
+#endif
 
 static inline bool scoutfs_forcing_unmount(struct super_block *sb)
 {

--- a/kmod/src/sysfs.c
+++ b/kmod/src/sysfs.c
@@ -13,6 +13,7 @@
 #include <linux/kernel.h>
 #include <linux/slab.h>
 #include <linux/fs.h>
+#include <linux/blkdev.h>
 
 #include "super.h"
 #include "sysfs.h"

--- a/kmod/src/triggers.c
+++ b/kmod/src/triggers.c
@@ -93,13 +93,9 @@ int scoutfs_setup_triggers(struct super_block *sb)
 		goto out;
 	}
 
-	for (i = 0; i < ARRAY_SIZE(triggers->atomics); i++) {
-		if (!debugfs_create_atomic_t(names[i], 0644, triggers->dir,
-					     &triggers->atomics[i])) {
-			ret = -ENOMEM;
-			goto out;
-		}
-	}
+	for (i = 0; i < ARRAY_SIZE(triggers->atomics); i++)
+		debugfs_create_atomic_t(names[i], 0644, triggers->dir,
+					&triggers->atomics[i]);
 
 	ret = 0;
 out:

--- a/kmod/src/tseq.c
+++ b/kmod/src/tseq.c
@@ -183,6 +183,13 @@ static void *scoutfs_tseq_seq_next(struct seq_file *m, void *v, loff_t *pos)
 	ent = tseq_rb_next(ent);
 	if (ent)
 		*pos = ent->pos;
+	else
+		/*
+		 * once we hit the end, *pos is never used, but it has to
+		 * be updated to avoid an error in bpf_seq_read()
+		 */
+		(*pos)++;
+
 	return ent;
 }
 

--- a/kmod/src/xattr.c
+++ b/kmod/src/xattr.c
@@ -882,7 +882,9 @@ static int scoutfs_xattr_get_handler
 
 static int scoutfs_xattr_set_handler
 #ifdef KC_XATTR_STRUCT_XATTR_HANDLER
-		(const struct xattr_handler *handler, struct dentry *dentry,
+		(const struct xattr_handler *handler,
+		 KC_VFS_NS_DEF
+		 struct dentry *dentry,
 		 struct inode *inode, const char *name, const void *value,
 		 size_t size, int flags)
 {

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -9,3 +9,5 @@ src/find_xattrs
 src/stage_tmpfile
 src/create_xattr_loop
 src/o_tmpfile_umask
+src/fragmented_data_extents
+src/filefrag-gc57857a5

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,8 @@ BIN := src/createmany			\
 	src/fragmented_data_extents	\
 	src/o_tmpfile_umask		\
 	src/parallel_restore		\
-	src/restore_copy
+	src/restore_copy		\
+	src/filefrag-gc57857a5
 
 DEPS := $(wildcard src/*.d)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,7 +12,8 @@ BIN := src/createmany			\
 	src/find_xattrs			\
 	src/create_xattr_loop		\
 	src/fragmented_data_extents	\
-	src/o_tmpfile_umask
+	src/o_tmpfile_umask		\
+	src/parallel_restore
 
 DEPS := $(wildcard src/*.d)
 
@@ -22,8 +23,11 @@ ifneq ($(DEPS),)
 -include $(DEPS)
 endif
 
+src/parallel_restore_cflags := ../utils/src/scoutfs_parallel_restore.a -lm
+
 $(BIN): %: %.c Makefile
-	gcc $(CFLAGS) -MD -MP -MF $*.d $< -o $@
+	gcc $(CFLAGS) -MD -MP -MF $*.d $< -o $@ $($(@)_cflags)
+
 
 .PHONY: clean
 clean:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,8 @@ BIN := src/createmany			\
 	src/create_xattr_loop		\
 	src/fragmented_data_extents	\
 	src/o_tmpfile_umask		\
-	src/parallel_restore
+	src/parallel_restore		\
+	src/restore_copy
 
 DEPS := $(wildcard src/*.d)
 
@@ -24,6 +25,7 @@ ifneq ($(DEPS),)
 endif
 
 src/parallel_restore_cflags := ../utils/src/scoutfs_parallel_restore.a -lm
+src/restore_copy_cflags := ../utils/src/scoutfs_parallel_restore.a -lm
 
 $(BIN): %: %.c Makefile
 	gcc $(CFLAGS) -MD -MP -MF $*.d $< -o $@ $($(@)_cflags)

--- a/tests/golden/data-prealloc
+++ b/tests/golden/data-prealloc
@@ -46,7 +46,7 @@ before:
 71.. 2: 
 79.. 2: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 0 at pos 0
 wrote blk 0
 0.. 1: 
@@ -59,7 +59,7 @@ wrote blk 0
 71.. 2: 
 79.. 2: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 0 at pos 1
 wrote blk 15
 0.. 1: 
@@ -73,7 +73,7 @@ wrote blk 15
 71.. 2: 
 79.. 2: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 0 at pos 2
 wrote blk 19
 0.. 1: 
@@ -90,7 +90,7 @@ wrote blk 19
 71.. 2: 
 79.. 2: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 1 at pos 0
 wrote blk 25
 0.. 1: 
@@ -109,7 +109,7 @@ wrote blk 25
 71.. 2: 
 79.. 2: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 1 at pos 1
 wrote blk 39
 0.. 1: 
@@ -129,7 +129,7 @@ wrote blk 39
 71.. 2: 
 79.. 2: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 1 at pos 2
 wrote blk 44
 0.. 1: 
@@ -151,7 +151,7 @@ wrote blk 44
 71.. 2: 
 79.. 2: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 2 at pos 0
 wrote blk 48
 0.. 1: 
@@ -175,7 +175,7 @@ wrote blk 48
 71.. 2: 
 79.. 2: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 2 at pos 1
 wrote blk 62
 0.. 1: 
@@ -201,7 +201,7 @@ wrote blk 62
 71.. 2: 
 79.. 2: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 2 at pos 2
 wrote blk 67
 0.. 1: 
@@ -230,7 +230,7 @@ wrote blk 67
 71.. 2: 
 79.. 2: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 3 at pos 0
 wrote blk 73
 0.. 1: 
@@ -261,7 +261,7 @@ wrote blk 73
 74.. 5: unwritten
 79.. 2: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 3 at pos 1
 wrote blk 86
 0.. 1: 
@@ -293,7 +293,7 @@ wrote blk 86
 79.. 2: 
 86.. 1: 
 87.. 2: 
-95.. 1: eof
+95.. 1: last,eof
 writing into existing 3 at pos 2
 wrote blk 92
 0.. 1: 
@@ -327,4 +327,4 @@ wrote blk 92
 87.. 2: 
 92.. 1: 
 93.. 2: unwritten
-95.. 1: eof
+95.. 1: last,eof

--- a/tests/golden/parallel_restore
+++ b/tests/golden/parallel_restore
@@ -4,7 +4,7 @@
 == compare filesystem contents
 committed_seq     1120
 total_meta_blocks 163840
-total_data_blocks 67108864
+total_data_blocks 15728640
    1440    1440   57120
      80      80     400
  ext:     logical_offset:        physical_offset: length:   expected: flags:
@@ -15,6 +15,9 @@ total_data_blocks 67108864
    0:        0..       0:          0..         0:      1:             last,unknown_loc,eof
  ext:     logical_offset:        physical_offset: length:   expected: flags:
    0:        0..       0:          0..         0:      1:             last,unknown_loc,eof
+    Type  Size     Total   Used      Free  Use%  
+MetaData  64KB    163840  34721    129119    21  
+    Data   4KB  15728640     64  15728576     0  
 == unmount small meta fs
 == ENOSPC
 == cleanup

--- a/tests/golden/parallel_restore
+++ b/tests/golden/parallel_restore
@@ -19,5 +19,10 @@ total_data_blocks 15728640
 MetaData  64KB    163840  34721    129119    21  
     Data   4KB  15728640     64  15728576     0  
 == unmount small meta fs
+== just under ENOSPC
+    Type  Size     Total    Used      Free  Use%
+MetaData  64KB    163840  163840         0   100
+    Data   4KB  15728640      64  15728576     0
+== just over ENOSPC
 == ENOSPC
 == cleanup

--- a/tests/golden/parallel_restore
+++ b/tests/golden/parallel_restore
@@ -7,6 +7,14 @@ total_meta_blocks 163840
 total_data_blocks 67108864
    1440    1440   57120
      80      80     400
+ ext:     logical_offset:        physical_offset: length:   expected: flags:
+   0:        0..       0:          0..         0:      1:             last,unknown_loc,eof
+ ext:     logical_offset:        physical_offset: length:   expected: flags:
+   0:        0..       0:          0..         0:      1:             last,unknown_loc,eof
+ ext:     logical_offset:        physical_offset: length:   expected: flags:
+   0:        0..       0:          0..         0:      1:             last,unknown_loc,eof
+ ext:     logical_offset:        physical_offset: length:   expected: flags:
+   0:        0..       0:          0..         0:      1:             last,unknown_loc,eof
 == unmount small meta fs
 == ENOSPC
 == cleanup

--- a/tests/golden/parallel_restore
+++ b/tests/golden/parallel_restore
@@ -1,0 +1,12 @@
+== make small meta fs
+== parallel_restore
+== mount restored filesystem
+== compare filesystem contents
+committed_seq     1120
+total_meta_blocks 163840
+total_data_blocks 67108864
+   1440    1440   57120
+     80      80     400
+== unmount small meta fs
+== ENOSPC
+== cleanup

--- a/tests/golden/setattr_more
+++ b/tests/golden/setattr_more
@@ -25,7 +25,7 @@ scoutfs: setattr failed: Invalid argument (22)
 Filesystem type is: 554f4353
 File size of /mnt/test/test/setattr_more/file is 40988672 (10007 blocks of 4096 bytes)
  ext:     logical_offset:        physical_offset: length:   expected: flags:
-   0:        0..   10006:          0..     10006:  10007:             unknown,eof
+   0:        0..   10006:          0..     10006:  10007:             last,unknown_loc,eof
 /mnt/test/test/setattr_more/file: 1 extent found
 == correct offline extent length
 976563

--- a/tests/sequence
+++ b/tests/sequence
@@ -49,4 +49,5 @@ archive-light-cycle.sh
 block-stale-reads.sh
 inode-deletion.sh
 renameat2-noreplace.sh
+parallel_restore.sh
 xfstests.sh

--- a/tests/src/filefrag-gc57857a5.c
+++ b/tests/src/filefrag-gc57857a5.c
@@ -1,0 +1,515 @@
+/*
+ * filefrag.c -- report if a particular file is fragmented
+ *
+ * Copyright 2003 by Theodore Ts'o.
+ *
+ * %Begin-Header%
+ * This file may be redistributed under the terms of the GNU Public
+ * License.
+ * %End-Header%
+ */
+
+/*
+ * This copy of filefrag.c was created from e2fsprogs-v1.45.6-26-gc57857a5
+ * in order to work around changes in the UNKNOWN flag causing the output to
+ * not display phys_offset properly for scoutfs offline extents.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <time.h>
+#include <fcntl.h>
+#include <errno.h>
+#ifdef HAVE_GETOPT_H
+#include <getopt.h>
+#else
+extern char *optarg;
+extern int optind;
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/vfs.h>
+#include <sys/ioctl.h>
+#ifdef HAVE_LINUX_FD_H
+#include <linux/fd.h>
+#endif
+
+#include <linux/types.h>
+
+#ifndef _LINUX_FIEMAP_H
+#define _LINUX_FIEMAP_H
+
+struct fiemap_extent {
+	__u64 fe_logical;  /* logical offset in bytes for the start of
+			    * the extent from the beginning of the file */
+	__u64 fe_physical; /* physical offset in bytes for the start
+			    * of the extent from the beginning of the disk */
+	__u64 fe_length;   /* length in bytes for this extent */
+	__u64 fe_reserved64[2];
+	__u32 fe_flags;    /* FIEMAP_EXTENT_* flags for this extent */
+	__u32 fe_reserved[3];
+};
+
+struct fiemap {
+	__u64 fm_start;		/* logical offset (inclusive) at
+				 * which to start mapping (in) */
+	__u64 fm_length;	/* logical length of mapping which
+				 * userspace wants (in) */
+	__u32 fm_flags;		/* FIEMAP_FLAG_* flags for request (in/out) */
+	__u32 fm_mapped_extents;/* number of extents that were mapped (out) */
+	__u32 fm_extent_count;  /* size of fm_extents array (in) */
+	__u32 fm_reserved;
+#if __GNUC_PREREQ (4, 8)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+	struct fiemap_extent fm_extents[0]; /* array of mapped extents (out) */
+#if __GNUC_PREREQ (4, 8)
+#pragma GCC diagnostic pop
+#endif
+};
+
+#if defined(__linux__) && !defined(FS_IOC_FIEMAP)
+#define FS_IOC_FIEMAP	_IOWR('f', 11, struct fiemap)
+#endif
+
+#define FIEMAP_MAX_OFFSET	(~0ULL)
+
+#define FIEMAP_FLAG_SYNC	0x00000001 /* sync file data before map */
+#define FIEMAP_FLAG_XATTR	0x00000002 /* map extended attribute tree */
+
+#define FIEMAP_FLAGS_COMPAT	(FIEMAP_FLAG_SYNC | FIEMAP_FLAG_XATTR)
+
+#define FIEMAP_EXTENT_LAST		0x00000001 /* Last extent in file. */
+#define FIEMAP_EXTENT_UNKNOWN		0x00000002 /* Data location unknown. */
+#define FIEMAP_EXTENT_DELALLOC		0x00000004 /* Location still pending.
+						    * Sets EXTENT_UNKNOWN. */
+#define FIEMAP_EXTENT_ENCODED		0x00000008 /* Data can not be read
+						    * while fs is unmounted */
+#define FIEMAP_EXTENT_DATA_ENCRYPTED	0x00000080 /* Data is encrypted by fs.
+						    * Sets EXTENT_NO_BYPASS. */
+#define FIEMAP_EXTENT_NOT_ALIGNED	0x00000100 /* Extent offsets may not be
+						    * block aligned. */
+#define FIEMAP_EXTENT_DATA_INLINE	0x00000200 /* Data mixed with metadata.
+						    * Sets EXTENT_NOT_ALIGNED.*/
+#define FIEMAP_EXTENT_DATA_TAIL		0x00000400 /* Multiple files in block.
+						    * Sets EXTENT_NOT_ALIGNED.*/
+#define FIEMAP_EXTENT_UNWRITTEN		0x00000800 /* Space allocated, but
+						    * no data (i.e. zero). */
+#define FIEMAP_EXTENT_MERGED		0x00001000 /* File does not natively
+						    * support extents. Result
+						    * merged for efficiency. */
+#define FIEMAP_EXTENT_SHARED		0x00002000 /* Space shared with other
+						    * files. */
+
+#endif /* _LINUX_FIEMAP_H */
+
+int verbose = 0;
+unsigned int blocksize;	/* Use specified blocksize (default 1kB) */
+int sync_file = 0;	/* fsync file before getting the mapping */
+int xattr_map = 0;	/* get xattr mapping */
+int force_bmap;	/* force use of FIBMAP instead of FIEMAP */
+int force_extent;	/* print output in extent format always */
+int logical_width = 8;
+int physical_width = 10;
+const char *ext_fmt = "%4d: %*llu..%*llu: %*llu..%*llu: %6llu: %s\n";
+const char *hex_fmt = "%4d: %*llx..%*llx: %*llx..%*llx: %6llx: %s\n";
+
+#define FILEFRAG_FIEMAP_FLAGS_COMPAT (FIEMAP_FLAG_SYNC | FIEMAP_FLAG_XATTR)
+
+#define FIBMAP		_IO(0x00, 1)	/* bmap access */
+#define FIGETBSZ	_IO(0x00, 2)	/* get the block size used for bmap */
+
+#define LUSTRE_SUPER_MAGIC 0x0BD00BD0
+
+#define	EXT4_EXTENTS_FL			0x00080000 /* Inode uses extents */
+#define	EXT3_IOC_GETFLAGS		_IOR('f', 1, long)
+
+static int ulong_log2(unsigned long arg)
+{
+	int     l = 0;
+
+	arg >>= 1;
+	while (arg) {
+		l++;
+		arg >>= 1;
+	}
+	return l;
+}
+
+static int ulong_log10(unsigned long long arg)
+{
+	int     l = 0;
+
+	arg = arg / 10;
+	while (arg) {
+		l++;
+		arg = arg / 10;
+	}
+	return l;
+}
+
+static void print_extent_header(void)
+{
+	printf(" ext: %*s %*s length: %*s flags:\n",
+	       logical_width * 2 + 3,
+	       "logical_offset:",
+	       physical_width * 2 + 3, "physical_offset:",
+	       physical_width + 1,
+	       "expected:");
+}
+
+static void print_flag(__u32 *flags, __u32 mask, char *buf, const char *name)
+{
+	if ((*flags & mask) == 0)
+		return;
+
+	strcat(buf, name);
+	*flags &= ~mask;
+}
+
+static void print_extent_info(struct fiemap_extent *fm_extent, int cur_ex,
+			      unsigned long long expected, int blk_shift,
+			      struct stat *st)
+{
+	unsigned long long physical_blk;
+	unsigned long long logical_blk;
+	unsigned long long ext_len;
+	unsigned long long ext_blks;
+	__u32 fe_flags, mask;
+	char flags[256] = "";
+
+	/* For inline data all offsets should be in bytes, not blocks */
+	if (fm_extent->fe_flags & FIEMAP_EXTENT_DATA_INLINE)
+		blk_shift = 0;
+
+	ext_len = fm_extent->fe_length >> blk_shift;
+	ext_blks = (fm_extent->fe_length - 1) >> blk_shift;
+	logical_blk = fm_extent->fe_logical >> blk_shift;
+	if (fm_extent->fe_flags & FIEMAP_EXTENT_UNKNOWN) {
+		physical_blk = 0;
+	} else {
+		physical_blk = fm_extent->fe_physical >> blk_shift;
+	}
+
+	if (expected)
+		sprintf(flags, ext_fmt == hex_fmt ? "%*llx: " : "%*llu: ",
+			physical_width, expected >> blk_shift);
+	else
+		sprintf(flags, "%.*s  ", physical_width, "                   ");
+
+	fe_flags = fm_extent->fe_flags;
+	print_flag(&fe_flags, FIEMAP_EXTENT_LAST, flags, "last,");
+	print_flag(&fe_flags, FIEMAP_EXTENT_UNKNOWN, flags, "unknown_loc,");
+	print_flag(&fe_flags, FIEMAP_EXTENT_DELALLOC, flags, "delalloc,");
+	print_flag(&fe_flags, FIEMAP_EXTENT_ENCODED, flags, "encoded,");
+	print_flag(&fe_flags, FIEMAP_EXTENT_DATA_ENCRYPTED, flags,"encrypted,");
+	print_flag(&fe_flags, FIEMAP_EXTENT_NOT_ALIGNED, flags, "not_aligned,");
+	print_flag(&fe_flags, FIEMAP_EXTENT_DATA_INLINE, flags, "inline,");
+	print_flag(&fe_flags, FIEMAP_EXTENT_DATA_TAIL, flags, "tail_packed,");
+	print_flag(&fe_flags, FIEMAP_EXTENT_UNWRITTEN, flags, "unwritten,");
+	print_flag(&fe_flags, FIEMAP_EXTENT_MERGED, flags, "merged,");
+	print_flag(&fe_flags, FIEMAP_EXTENT_SHARED, flags, "shared,");
+	/* print any unknown flags as hex values */
+	for (mask = 1; fe_flags != 0 && mask != 0; mask <<= 1) {
+		char hex[sizeof(mask) * 2 + 4]; /* 2 chars/byte + 0x, + NUL */
+
+		if ((fe_flags & mask) == 0)
+			continue;
+		sprintf(hex, "%#04x,", mask);
+		print_flag(&fe_flags, mask, flags, hex);
+	}
+
+	if (fm_extent->fe_logical + fm_extent->fe_length >=
+	    (unsigned long long) st->st_size)
+		strcat(flags, "eof,");
+
+	/* Remove trailing comma, if any */
+	if (flags[0] != '\0')
+		flags[strnlen(flags, sizeof(flags)) - 1] = '\0';
+
+	printf(ext_fmt, cur_ex, logical_width, logical_blk,
+	       logical_width, logical_blk + ext_blks,
+	       physical_width, physical_blk,
+	       physical_width, physical_blk + ext_blks,
+	       ext_len, flags);
+}
+
+static int filefrag_fiemap(int fd, int blk_shift, int *num_extents,
+			   struct stat *st)
+{
+	__u64 buf[2048];	/* __u64 for proper field alignment */
+	struct fiemap *fiemap = (struct fiemap *)buf;
+	struct fiemap_extent *fm_ext = &fiemap->fm_extents[0];
+	struct fiemap_extent fm_last;
+	int count = (sizeof(buf) - sizeof(*fiemap)) /
+			sizeof(struct fiemap_extent);
+	unsigned long long expected = 0;
+	unsigned long long expected_dense = 0;
+	unsigned long flags = 0;
+	unsigned int i;
+	int fiemap_header_printed = 0;
+	int tot_extents = 0, n = 0;
+	int last = 0;
+	int rc;
+
+	memset(fiemap, 0, sizeof(struct fiemap));
+	memset(&fm_last, 0, sizeof(fm_last));
+
+	if (sync_file)
+		flags |= FIEMAP_FLAG_SYNC;
+
+	if (xattr_map)
+		flags |= FIEMAP_FLAG_XATTR;
+
+	do {
+		fiemap->fm_length = ~0ULL;
+		fiemap->fm_flags = flags;
+		fiemap->fm_extent_count = count;
+		rc = ioctl(fd, FS_IOC_FIEMAP, (unsigned long) fiemap);
+		if (rc < 0) {
+			static int fiemap_incompat_printed;
+
+			rc = -errno;
+			if (rc == -EBADR && !fiemap_incompat_printed) {
+				fprintf(stderr, "FIEMAP failed with unknown "
+						"flags %x\n",
+				       fiemap->fm_flags);
+				fiemap_incompat_printed = 1;
+			}
+			return rc;
+		}
+
+		/* If 0 extents are returned, then more ioctls are not needed */
+		if (fiemap->fm_mapped_extents == 0)
+			break;
+
+		if (verbose && !fiemap_header_printed) {
+			print_extent_header();
+			fiemap_header_printed = 1;
+		}
+
+		for (i = 0; i < fiemap->fm_mapped_extents; i++) {
+			expected_dense = fm_last.fe_physical +
+					 fm_last.fe_length;
+			expected = fm_last.fe_physical +
+				   fm_ext[i].fe_logical - fm_last.fe_logical;
+			if (fm_ext[i].fe_logical != 0 &&
+			    fm_ext[i].fe_physical != expected &&
+			    fm_ext[i].fe_physical != expected_dense) {
+				tot_extents++;
+			} else {
+				expected = 0;
+				if (!tot_extents)
+					tot_extents = 1;
+			}
+			if (verbose)
+				print_extent_info(&fm_ext[i], n, expected,
+						  blk_shift, st);
+			if (fm_ext[i].fe_flags & FIEMAP_EXTENT_LAST)
+				last = 1;
+			fm_last = fm_ext[i];
+			n++;
+		}
+
+		fiemap->fm_start = (fm_ext[i - 1].fe_logical +
+				    fm_ext[i - 1].fe_length);
+	} while (last == 0);
+
+	*num_extents = tot_extents;
+
+	return 0;
+}
+
+#define EXT2_DIRECT	12
+
+
+static int frag_report(const char *filename)
+{
+	static struct statfs fsinfo;
+	static unsigned int blksize;
+	struct stat	st;
+	int		blk_shift;
+	long		fd;
+	unsigned long long	numblocks;
+	int		num_extents = 1;
+	static dev_t	last_device;
+	int		width;
+	int		rc = 0;
+
+#if defined(HAVE_OPEN64) && !defined(__OSX_AVAILABLE_BUT_DEPRECATED)
+	fd = open64(filename, O_RDONLY);
+#else
+	fd = open(filename, O_RDONLY);
+#endif
+	if (fd < 0) {
+		rc = -errno;
+		perror("open");
+		return rc;
+	}
+
+#if defined(HAVE_FSTAT64) && !defined(__OSX_AVAILABLE_BUT_DEPRECATED)
+	if (fstat64(fd, &st) < 0) {
+#else
+	if (fstat(fd, &st) < 0) {
+#endif
+		rc = -errno;
+		perror("stat");
+		goto out_close;
+	}
+
+	if ((last_device != st.st_dev) || !st.st_dev) {
+		if (fstatfs(fd, &fsinfo) < 0) {
+			rc = -errno;
+			perror("fstatfs");
+			goto out_close;
+		}
+		if ((ioctl(fd, FIGETBSZ, &blksize) < 0) || !blksize)
+			blksize = fsinfo.f_bsize;
+		if (verbose)
+			printf("Filesystem type is: %lx\n",
+			       (unsigned long)fsinfo.f_type);
+	}
+	st.st_blksize = blksize;
+
+	last_device = st.st_dev;
+
+	width = ulong_log10(fsinfo.f_blocks);
+	if (width > physical_width)
+		physical_width = width;
+
+	numblocks = (st.st_size + blksize - 1) / blksize;
+	if (blocksize != 0)
+		blk_shift = ulong_log2(blocksize);
+	else
+		blk_shift = ulong_log2(blksize);
+
+	width = ulong_log10(numblocks);
+	if (width > logical_width)
+		logical_width = width;
+	if (verbose)
+		printf("File size of %s is %llu (%llu block%s of %d bytes)\n",
+		       filename, (unsigned long long)st.st_size,
+		       numblocks * blksize >> blk_shift,
+		       numblocks == 1 ? "" : "s", 1 << blk_shift);
+
+	rc = filefrag_fiemap(fd, blk_shift, &num_extents, &st);
+
+	if (num_extents == 1)
+		printf("%s: 1 extent found", filename);
+	else
+		printf("%s: %d extents found", filename, num_extents);
+	fputc('\n', stdout);
+out_close:
+	close(fd);
+
+	return rc;
+}
+
+static void usage(const char *progname)
+{
+	fprintf(stderr, "Usage: %s [-b{blocksize}[KMG]] [-BeksvxX] file ...\n",
+		progname);
+	exit(1);
+}
+
+int main(int argc, char**argv)
+{
+	char **cpp;
+	int rc = 0, c;
+
+	while ((c = getopt(argc, argv, "Bb::eksvxX")) != EOF) {
+		switch (c) {
+		case 'B':
+			force_bmap++;
+			break;
+		case 'b':
+			if (optarg) {
+				char *end;
+				unsigned long val;
+
+				val = strtoul(optarg, &end, 0);
+				if (end) {
+#if __GNUC_PREREQ (7, 0)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+					switch (end[0]) {
+					case 'g':
+					case 'G':
+						val *= 1024;
+						/* fall through */
+					case 'm':
+					case 'M':
+						val *= 1024;
+						/* fall through */
+					case 'k':
+					case 'K':
+						val *= 1024;
+						break;
+					default:
+						break;
+					}
+#if __GNUC_PREREQ (7, 0)
+#pragma GCC diagnostic pop
+#endif
+				}
+				/* Specifying too large a blocksize will just
+				 * shift all extents down to zero length. Even
+				 * 1GB is questionable, but caveat emptor. */
+				if (val > 1024 * 1024 * 1024) {
+					fprintf(stderr,
+						"%s: blocksize %lu over 1GB\n",
+						argv[0], val);
+					usage(argv[0]);
+				}
+				blocksize = val;
+			} else { /* Allow -b without argument for compat. Remove
+				  * this eventually so "-b {blocksize}" works */
+				fprintf(stderr, "%s: -b needs a blocksize "
+					"option, assuming 1024-byte blocks.\n",
+					argv[0]);
+				blocksize = 1024;
+			}
+			break;
+		case 'e':
+			force_extent++;
+			if (!verbose)
+				verbose++;
+			break;
+		case 'k':
+			blocksize = 1024;
+			break;
+		case 's':
+			sync_file++;
+			break;
+		case 'v':
+			verbose++;
+			break;
+		case 'x':
+			xattr_map++;
+			break;
+		case 'X':
+			ext_fmt = hex_fmt;
+			break;
+		default:
+			usage(argv[0]);
+			break;
+		}
+	}
+
+	if (optind == argc)
+		usage(argv[0]);
+
+	for (cpp = argv + optind; *cpp != NULL; cpp++) {
+		int rc2 = frag_report(*cpp);
+
+		if (rc2 < 0 && rc == 0)
+			rc = rc2;
+	}
+
+	return -rc;
+}

--- a/tests/src/parallel_restore.c
+++ b/tests/src/parallel_restore.c
@@ -170,6 +170,8 @@ static struct gen_inode *generate_inode(struct opts *opts, u64 ino, mode_t mode)
 
 	gino->inode = (struct scoutfs_parallel_restore_inode) {
 		.ino = ino,
+		.meta_seq = ino,
+		.data_seq = 0,
 		.mode = mode,
 		.atime = now,
 		.ctime = now,

--- a/tests/src/parallel_restore.c
+++ b/tests/src/parallel_restore.c
@@ -1,0 +1,782 @@
+#define _GNU_SOURCE /* O_DIRECT */
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/xattr.h>
+#include <ctype.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <time.h>
+#include <sys/prctl.h>
+#include <signal.h>
+#include <sys/socket.h>
+
+#include "../../utils/src/sparse.h"
+#include "../../utils/src/util.h"
+#include "../../utils/src/list.h"
+#include "../../utils/src/parse.h"
+#include "../../kmod/src/format.h"
+#include "../../utils/src/parallel_restore.h"
+
+/*
+ * XXX:
+ *  - add a nice description of what's going on
+ *  - mention allocator contention
+ *  - test child process dying handling
+ *  - root dir entry name length is wrong
+ */
+
+#define ERRF " errno %d (%s)"
+#define ERRA errno, strerror(errno)
+
+#define error_exit(cond, fmt, args...)			\
+do {							\
+	if (cond) {					\
+		printf("error: "fmt"\n", ##args);	\
+		exit(1);				\
+	}						\
+} while (0)
+
+#define dprintf(fmt, args...)		\
+do {					\
+	if (0)				\
+		printf(fmt, ##args);	\
+} while (0)
+
+#define REG_MODE (S_IFREG | 0644)
+#define DIR_MODE (S_IFDIR | 0755)
+
+struct opts {
+	unsigned long long buf_size;
+
+	unsigned long long write_batch;
+	unsigned long long low_dirs;
+	unsigned long long high_dirs;
+	unsigned long long low_files;
+	unsigned long long high_files;
+	char *meta_path;
+	unsigned long long total_files;
+	bool read_only;
+	unsigned long long seed;
+	unsigned long long nr_writers;
+};
+
+static void usage(void)
+{
+	printf("usage:\n"
+	       " -b NR       | threads write blocks in batches files (100000)\n"
+	       " -d LOW:HIGH | range of subdirs per directory (5:10)\n"
+	       " -f LOW:HIGH | range of files per directory (10:20)\n"
+	       " -m PATH     | path to metadata device\n"
+	       " -n NR       | total number of files to create (100)\n"
+	       " -r          | read-only, all work except writing, measure cpu cost\n"
+	       " -s NR       | randomization seed (random)\n"
+	       " -w NR       | number of writing processes to fork (online cpus)\n"
+	       );
+}
+
+static size_t write_bufs(struct opts *opts, struct scoutfs_parallel_restore_writer *wri,
+			 void *buf, size_t buf_size, int dev_fd)
+{
+	size_t total = 0;
+	size_t count;
+	off_t off;
+	int ret;
+
+	do {
+		ret = scoutfs_parallel_restore_write_buf(wri, buf, buf_size, &off, &count);
+		error_exit(ret, "write buf %d", ret);
+
+		if (count > 0) {
+			if (!opts->read_only)
+				ret = pwrite(dev_fd, buf, count, off);
+			else
+				ret = count;
+			error_exit(ret != count, "pwrite count %zu ret %d", count, ret);
+			total += ret;
+		}
+	} while (count > 0);
+
+	return total;
+}
+
+struct gen_inode {
+	struct scoutfs_parallel_restore_inode inode;
+	struct scoutfs_parallel_restore_xattr **xattrs;
+	u64 nr_xattrs;
+	struct scoutfs_parallel_restore_entry **entries;
+	u64 nr_files;
+	u64 nr_entries;
+};
+
+static void free_gino(struct gen_inode *gino)
+{
+	u64 i;
+
+	if (gino) {
+		if (gino->entries) {
+			for (i = 0; i < gino->nr_entries; i++)
+				free(gino->entries[i]);
+			free(gino->entries);
+		}
+		if (gino->xattrs) {
+			for (i = 0; i < gino->nr_xattrs; i++)
+				free(gino->xattrs[i]);
+			free(gino->xattrs);
+		}
+		free(gino);
+	}
+}
+
+static struct scoutfs_parallel_restore_xattr *
+generate_xattr(struct opts *opts, u64 ino, u64 pos, char *name, int name_len, void *value,
+		int value_len)
+{
+	struct scoutfs_parallel_restore_xattr *xattr;
+
+	xattr = malloc(sizeof(struct scoutfs_parallel_restore_xattr) + name_len + value_len);
+	error_exit(!xattr, "error allocating generated xattr");
+
+	*xattr = (struct scoutfs_parallel_restore_xattr) {
+		.ino = ino,
+		.pos = pos,
+		.name_len = name_len,
+		.value_len = value_len,
+	};
+
+	xattr->name = (void *)(xattr + 1);
+	xattr->value = (void *)(xattr->name + name_len);
+
+	memcpy(xattr->name, name, name_len);
+	if (value_len)
+		memcpy(xattr->value, value, value_len);
+
+	return xattr;
+}
+
+static struct gen_inode *generate_inode(struct opts *opts, u64 ino, mode_t mode)
+{
+	struct gen_inode *gino;
+	struct timespec now;
+
+	clock_gettime(CLOCK_REALTIME, &now);
+
+	gino = calloc(1, sizeof(struct gen_inode));
+	error_exit(!gino, "failure allocating generated inode");
+
+	gino->inode = (struct scoutfs_parallel_restore_inode) {
+		.ino = ino,
+		.mode = mode,
+		.atime = now,
+		.ctime = now,
+		.mtime = now,
+		.crtime = now,
+	};
+
+	/*
+	 * hacky creation of a bunch of xattrs for now.
+	 */
+	if ((mode & S_IFMT) == S_IFREG) {
+		#define NV(n, v) { n, sizeof(n) - 1, v, sizeof(v) - 1, }
+		struct name_val {
+			char *name;
+			int len;
+			char *value;
+			int value_len;
+		} nv[] = {
+			NV("scoutfs.hide.totl.acct.8314611887310466424.2.0", "1"),
+			NV("scoutfs.hide.srch.sam_vol_E01001L6_4", ""),
+			NV("scoutfs.hide.sam_reqcopies", ""),
+			NV("scoutfs.hide.sam_copy_2", ""),
+			NV("scoutfs.hide.totl.acct.F01030L6.8314611887310466424.7.30", "1"),
+			NV("scoutfs.hide.sam_copy_1", ""),
+			NV("scoutfs.hide.srch.sam_vol_F01030L6_4", ""),
+			NV("scoutfs.hide.srch.sam_release_cand", ""),
+			NV("scoutfs.hide.sam_restime", ""),
+			NV("scoutfs.hide.sam_uuid", ""),
+			NV("scoutfs.hide.totl.acct.8314611887310466424.3.0", "1"),
+			NV("scoutfs.hide.srch.sam_vol_F01030L6", ""),
+			NV("scoutfs.hide.srch.sam_uuid_865939b7-24d6-472f-b85c-7ce7afeb813a", ""),
+			NV("scoutfs.hide.srch.sam_vol_E01001L6", ""),
+			NV("scoutfs.hide.totl.acct.E01001L6.8314611887310466424.7.1", "1"),
+			NV("scoutfs.hide.totl.acct.8314611887310466424.4.0", "1"),
+			NV("scoutfs.hide.totl.acct.8314611887310466424.11.0", "1"),
+			NV("scoutfs.hide.totl.acct.8314611887310466424.1.0", "1"),
+		};
+		unsigned int nr = array_size(nv);
+		int i;
+
+		gino->xattrs = calloc(nr, sizeof(struct scoutfs_parallel_restore_xattr *));
+
+		for (i = 0; i < nr; i++)
+			gino->xattrs[i] = generate_xattr(opts, ino, i, nv[i].name, nv[i].len,
+							 nv[i].value, nv[i].value_len);
+
+		gino->nr_xattrs = nr;
+		gino->inode.nr_xattrs = nr;
+	}
+
+	return gino;
+}
+
+static struct scoutfs_parallel_restore_entry *
+generate_entry(struct opts *opts, char *prefix, u64 nr, u64 dir_ino, u64 pos, u64 ino, mode_t mode)
+{
+	struct scoutfs_parallel_restore_entry *entry;
+	char buf[PATH_MAX];
+	int bytes;
+
+	bytes = snprintf(buf, sizeof(buf), "%s-%llu", prefix, nr);
+
+	entry = malloc(sizeof(struct scoutfs_parallel_restore_entry) + bytes);
+	error_exit(!entry, "error allocating generated entry");
+
+	*entry = (struct scoutfs_parallel_restore_entry) {
+		.dir_ino = dir_ino,
+		.pos = pos,
+		.ino = ino,
+		.mode = mode,
+		.name = (void *)(entry + 1),
+		.name_len = bytes,
+	};
+
+	memcpy(entry->name, buf, bytes);
+
+	return entry;
+}
+
+static u64 random64(void)
+{
+	return ((u64)lrand48() << 32) | lrand48();
+}
+
+static u64 random_range(u64 low, u64 high)
+{
+	return low + (random64() % (high - low + 1));
+}
+
+static struct gen_inode *generate_dir(struct opts *opts, u64 dir_ino, u64 ino_start, u64 ino_len,
+				      bool no_dirs)
+{
+	struct scoutfs_parallel_restore_entry *entry;
+	struct gen_inode *gino;
+	u64 nr_entries;
+	u64 nr_files;
+	u64 nr_dirs;
+	u64 ino;
+	char *prefix;
+	mode_t mode;
+	u64 i;
+
+	nr_dirs = no_dirs ? 0 : random_range(opts->low_dirs, opts->high_dirs);
+	nr_files = random_range(opts->low_files, opts->high_files);
+
+	if (1 + nr_dirs + nr_files > ino_len) {
+		nr_dirs = no_dirs ? 0 : (ino_len - 1) / 2;
+		nr_files = (ino_len - 1) - nr_dirs;
+	}
+
+	nr_entries = nr_dirs + nr_files;
+
+	gino = generate_inode(opts, dir_ino, DIR_MODE);
+	error_exit(!gino, "error allocating generated inode");
+
+	gino->inode.nr_subdirs = nr_dirs;
+	gino->nr_files = nr_files;
+
+	if (nr_entries) {
+		gino->entries = calloc(nr_entries, sizeof(struct scoutfs_parallel_restore_entry *));
+		error_exit(!gino->entries, "error allocating generated inode entries");
+
+		gino->nr_entries = nr_entries;
+	}
+
+	mode = DIR_MODE;
+	prefix = "dir";
+	for (i = 0; i < nr_entries; i++) {
+		if (i == nr_dirs) {
+			mode = REG_MODE;
+			prefix = "file";
+		}
+
+		ino = ino_start + i;
+		entry = generate_entry(opts, prefix, ino, gino->inode.ino,
+				       SCOUTFS_DIRENT_FIRST_POS + i, ino, mode);
+
+		gino->entries[i] = entry;
+		gino->inode.total_entry_name_bytes += entry->name_len;
+	}
+
+	return gino;
+}
+
+/*
+ * Restore a generated inode.  If it's a directory then we also restore
+ * all its entries.  The caller is going to descend into subdir entries and generate
+ * those dir inodes.  We have to generate and restore all non-dir inodes referenced
+ * by this inode's entries.
+ */
+static void restore_inode(struct opts *opts, struct scoutfs_parallel_restore_writer *wri,
+			  struct gen_inode *gino)
+{
+	struct gen_inode *nondir;
+	int ret;
+	u64 i;
+
+	ret = scoutfs_parallel_restore_add_inode(wri, &gino->inode);
+	error_exit(ret, "thread add root inode %d", ret);
+
+	for (i = 0; i < gino->nr_entries; i++) {
+		ret = scoutfs_parallel_restore_add_entry(wri, gino->entries[i]);
+		error_exit(ret, "thread add entry %d", ret);
+
+		/* caller only needs subdir entries, generate and free others */
+		if ((gino->entries[i]->mode & S_IFMT) != S_IFDIR) {
+
+			nondir = generate_inode(opts, gino->entries[i]->ino,
+						gino->entries[i]->mode);
+			restore_inode(opts, wri, nondir);
+			free_gino(nondir);
+
+			free(gino->entries[i]);
+			if (i != gino->nr_entries - 1)
+				gino->entries[i] = gino->entries[gino->nr_entries - 1];
+			gino->nr_entries--;
+			gino->nr_files--;
+			i--;
+		}
+	}
+
+	for (i = 0; i < gino->nr_xattrs; i++) {
+		ret = scoutfs_parallel_restore_add_xattr(wri, gino->xattrs[i]);
+		error_exit(ret, "thread add xattr %d", ret);
+	}
+}
+
+struct writer_args {
+	struct list_head head;
+
+	int dev_fd;
+	int pair_fd;
+
+	struct scoutfs_parallel_restore_slice slice;
+	u64 writer_nr;
+	u64 dir_height;
+	u64 ino_start;
+	u64 ino_len;
+};
+
+struct write_result {
+	struct scoutfs_parallel_restore_progress prog;
+	struct scoutfs_parallel_restore_slice slice;
+	__le64 files_created;
+	__le64 bytes_written;
+};
+
+static void write_bufs_and_send(struct opts *opts, struct scoutfs_parallel_restore_writer *wri,
+				  void *buf, size_t buf_size, int dev_fd,
+				  struct write_result *res, bool get_slice, int pair_fd)
+{
+	size_t total;
+	int ret;
+
+	total = write_bufs(opts, wri, buf, buf_size, dev_fd);
+	le64_add_cpu(&res->bytes_written, total);
+
+	ret = scoutfs_parallel_restore_get_progress(wri, &res->prog);
+	error_exit(ret, "get prog %d", ret);
+
+	if (get_slice) {
+		ret = scoutfs_parallel_restore_get_slice(wri, &res->slice);
+		error_exit(ret, "thread get slice %d", ret);
+	}
+
+	ret = write(pair_fd, res, sizeof(struct write_result));
+	error_exit(ret != sizeof(struct write_result), "result send error");
+
+	memset(res, 0, sizeof(struct write_result));
+}
+
+/*
+ * Calculate the number of bytes in toplevel "dir-%llu" entry names for the given
+ * number of writers.
+ */
+static u64 topdir_entry_bytes(u64 nr_writers)
+{
+	u64 bytes = (3 + 1) * nr_writers;
+	u64 limit;
+	u64 done;
+	u64 wid;
+	u64 nr;
+
+	for (done = 0, wid = 1, limit = 10; done < nr_writers; done += nr, wid++, limit *= 10) {
+		nr = min(limit - done, nr_writers - done);
+		bytes += nr * wid;
+	}
+
+	return bytes;
+}
+
+struct dir_pos {
+	struct gen_inode *gino;
+	u64 pos;
+};
+
+static void writer_proc(struct opts *opts, struct writer_args *args)
+{
+	struct scoutfs_parallel_restore_writer *wri = NULL;
+	struct scoutfs_parallel_restore_entry *entry;
+	struct dir_pos *dirs = NULL;
+	struct write_result res;
+	struct gen_inode *gino;
+	void *buf = NULL;
+	u64 level;
+	u64 ino;
+	int ret;
+
+	memset(&res, 0, sizeof(res));
+
+	dirs = calloc(args->dir_height, sizeof(struct dir_pos));
+	error_exit(errno, "error allocating parent dirs "ERRF, ERRA);
+
+	errno = posix_memalign((void **)&buf, 4096, opts->buf_size);
+	error_exit(errno, "error allocating block buf "ERRF, ERRA);
+
+	ret = scoutfs_parallel_restore_create_writer(&wri);
+	error_exit(ret, "create writer %d", ret);
+
+	ret = scoutfs_parallel_restore_add_slice(wri, &args->slice);
+	error_exit(ret, "add slice %d", ret);
+
+	/* writer 0 creates the root dir */
+	if (args->writer_nr == 0) {
+		gino = generate_inode(opts, SCOUTFS_ROOT_INO, DIR_MODE);
+		gino->inode.nr_subdirs = opts->nr_writers;
+		gino->inode.total_entry_name_bytes = topdir_entry_bytes(opts->nr_writers);
+
+		ret = scoutfs_parallel_restore_add_inode(wri, &gino->inode);
+		error_exit(ret, "thread add root inode %d", ret);
+		free_gino(gino);
+	}
+
+	/* create root entry for our top level dir */
+	ino = args->ino_start++;
+	args->ino_len--;
+
+	entry = generate_entry(opts, "top", args->writer_nr,
+			       SCOUTFS_ROOT_INO, SCOUTFS_DIRENT_FIRST_POS + args->writer_nr,
+			       ino, DIR_MODE);
+
+	ret = scoutfs_parallel_restore_add_entry(wri, entry);
+	error_exit(ret, "thread top entry %d", ret);
+	free(entry);
+
+	level = args->dir_height - 1;
+
+	while (args->ino_len > 0 && level < args->dir_height) {
+		gino = dirs[level].gino;
+
+		/* generate and restore if we follow entries */
+		if (!gino) {
+			gino = generate_dir(opts, ino, args->ino_start, args->ino_len, level == 0);
+			args->ino_start += gino->nr_entries;
+			args->ino_len -= gino->nr_entries;
+			le64_add_cpu(&res.files_created, gino->nr_files);
+
+			restore_inode(opts, wri, gino);
+			dirs[level].gino = gino;
+		}
+
+		if (dirs[level].pos == gino->nr_entries) {
+			/* ascend if we're done with this dir */
+			dirs[level].gino = NULL;
+			dirs[level].pos = 0;
+			free_gino(gino);
+			level++;
+
+		} else {
+			/* otherwise descend into subdir entry */
+			ino = gino->entries[dirs[level].pos]->ino;
+			dirs[level].pos++;
+			level--;
+		}
+
+		/* do a partial write at batch intervals when there's still more to do */
+		if (le64_to_cpu(res.files_created) >= opts->write_batch && args->ino_len > 0)
+			write_bufs_and_send(opts, wri, buf, opts->buf_size, args->dev_fd,
+					    &res, false, args->pair_fd);
+	}
+
+	write_bufs_and_send(opts, wri, buf, opts->buf_size, args->dev_fd,
+			    &res, true, args->pair_fd);
+
+	scoutfs_parallel_restore_destroy_writer(&wri);
+
+	free(dirs);
+	free(buf);
+}
+
+static void fork_writer(struct opts *opts, struct writer_args *args)
+{
+	pid_t parent = getpid();
+	pid_t pid;
+	int ret;
+
+	pid = fork();
+	error_exit(pid == -1, "fork error");
+
+	if (pid != 0)
+		return;
+
+	ret = prctl(PR_SET_PDEATHSIG, SIGHUP);
+	error_exit(ret < 0, "failed to set parent death sig");
+
+	printf("pid %u getpid() %u parent %u getppid() %u\n",
+		pid, getpid(), parent, getppid());
+	error_exit(getppid() != parent, "child parent already changed");
+
+	writer_proc(opts, args);
+	exit(0);
+}
+
+static int do_restore(struct opts *opts)
+{
+	struct scoutfs_parallel_restore_writer *wri = NULL;
+	struct scoutfs_parallel_restore_slice *slices = NULL;
+	struct scoutfs_super_block *super = NULL;
+	struct write_result res;
+	struct writer_args *args;
+	struct timespec begin;
+	struct timespec end;
+	LIST_HEAD(writers);
+	u64 next_ino;
+	u64 ino_per;
+	u64 avg_dirs;
+	u64 avg_files;
+	u64 dir_height;
+	u64 tot_files;
+	u64 tot_bytes;
+	int pair[2] = {-1, -1};
+	float secs;
+	void *buf = NULL;
+	int dev_fd = -1;
+	int ret;
+	int i;
+
+	ret = socketpair(PF_LOCAL, SOCK_STREAM, 0, pair);
+	error_exit(ret, "socketpair error "ERRF, ERRA);
+
+	dev_fd = open(opts->meta_path, O_DIRECT | (opts->read_only ? O_RDONLY : (O_RDWR|O_EXCL)));
+	error_exit(dev_fd < 0, "error opening '%s': "ERRF, opts->meta_path, ERRA);
+
+	errno = posix_memalign((void **)&super, 4096, SCOUTFS_BLOCK_SM_SIZE) ?:
+		posix_memalign((void **)&buf, 4096, opts->buf_size);
+	error_exit(errno, "error allocating block bufs "ERRF, ERRA);
+
+	ret = pread(dev_fd, super, SCOUTFS_BLOCK_SM_SIZE,
+		    SCOUTFS_SUPER_BLKNO << SCOUTFS_BLOCK_SM_SHIFT);
+	error_exit(ret != SCOUTFS_BLOCK_SM_SIZE, "error reading super, ret %d", ret);
+
+	ret = scoutfs_parallel_restore_create_writer(&wri);
+	error_exit(ret, "create writer %d", ret);
+
+	ret = scoutfs_parallel_restore_import_super(wri, super);
+	error_exit(ret, "import super %d", ret);
+
+	slices = calloc(1 + opts->nr_writers, sizeof(struct scoutfs_parallel_restore_slice));
+	error_exit(!slices, "alloc slices");
+
+	scoutfs_parallel_restore_init_slices(wri, slices, 1 + opts->nr_writers);
+
+	ret = scoutfs_parallel_restore_add_slice(wri, &slices[0]);
+	error_exit(ret, "add slices[0] %d", ret);
+
+	next_ino = (SCOUTFS_ROOT_INO | SCOUTFS_LOCK_INODE_GROUP_MASK) + 1;
+	ino_per = opts->total_files / opts->nr_writers;
+	avg_dirs = (opts->low_dirs + opts->high_dirs) / 2;
+	avg_files = (opts->low_files + opts->high_files) / 2;
+
+	dir_height = 1;
+	tot_files = avg_files * opts->nr_writers;
+
+	while (tot_files < opts->total_files) {
+		dir_height++;
+		tot_files *= avg_dirs;
+	}
+
+	dprintf("height %llu tot %llu total %llu\n", dir_height, tot_files, opts->total_files);
+
+	clock_gettime(CLOCK_MONOTONIC_RAW, &begin);
+
+	/* start each writing process */
+	for (i = 0; i < opts->nr_writers; i++) {
+		args = calloc(1, sizeof(struct writer_args));
+		error_exit(!args, "alloc writer args");
+
+		args->dev_fd = dev_fd;
+		args->pair_fd = pair[1];
+		args->slice = slices[1 + i];
+		args->writer_nr = i;
+		args->dir_height = dir_height;
+		args->ino_start = next_ino;
+		args->ino_len = ino_per;
+
+		list_add_tail(&args->head, &writers);
+		next_ino += ino_per;
+
+		fork_writer(opts, args);
+	}
+
+	/* read results and watch for writers to finish */
+	tot_files = 0;
+	tot_bytes = 0;
+	i = 0;
+	while (i < opts->nr_writers) {
+		ret = read(pair[0], &res, sizeof(struct write_result));
+		error_exit(ret != sizeof(struct write_result), "result read error");
+
+		ret = scoutfs_parallel_restore_add_progress(wri, &res.prog);
+		error_exit(ret, "add thr prog %d", ret);
+
+		if (res.slice.meta_len != 0) {
+			ret = scoutfs_parallel_restore_add_slice(wri, &res.slice);
+			error_exit(ret, "add thr slice %d", ret);
+			i++;
+		}
+
+		tot_files += le64_to_cpu(res.files_created);
+		tot_bytes += le64_to_cpu(res.bytes_written);
+	}
+
+	tot_bytes += write_bufs(opts, wri, buf, opts->buf_size, dev_fd);
+
+	ret = scoutfs_parallel_restore_export_super(wri, super);
+	error_exit(ret, "update super %d", ret);
+
+	if (!opts->read_only) {
+		ret = pwrite(dev_fd, super, SCOUTFS_BLOCK_SM_SIZE,
+			     SCOUTFS_SUPER_BLKNO << SCOUTFS_BLOCK_SM_SHIFT);
+		error_exit(ret != SCOUTFS_BLOCK_SM_SIZE, "error writing super, ret %d", ret);
+	}
+
+	clock_gettime(CLOCK_MONOTONIC_RAW, &end);
+
+	scoutfs_parallel_restore_destroy_writer(&wri);
+
+	secs = ((float)end.tv_sec + ((float)end.tv_nsec/NSEC_PER_SEC)) -
+	       ((float)begin.tv_sec + ((float)begin.tv_nsec/NSEC_PER_SEC));
+	printf("created %llu files in %llu bytes and %f secs => %f bytes/file, %f files/sec\n",
+		tot_files, tot_bytes, secs,
+		(float)tot_bytes / tot_files, (float)tot_files / secs);
+
+	if (dev_fd >= 0)
+		close(dev_fd);
+	if (pair[0] >= 0)
+		close(pair[0]);
+	if (pair[1] >= 0)
+		close(pair[1]);
+	free(super);
+	free(slices);
+	free(buf);
+
+	return 0;
+}
+
+static int parse_low_high(char *str, u64 *low_ret, u64 *high_ret)
+{
+	char *sep;
+	int ret = 0;
+
+	sep = index(str, ':');
+	if (sep) {
+		*sep = '\0';
+		ret = parse_u64(sep + 1, high_ret);
+	}
+
+	if (ret == 0)
+		ret = parse_u64(str, low_ret);
+
+	if (sep)
+		*sep = ':';
+
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	struct opts opts = {
+		.buf_size = (32 * 1024 * 1024),
+
+		.write_batch = 1000000,
+		.low_dirs = 5,
+		.high_dirs = 10,
+		.low_files = 10,
+		.high_files = 20,
+		.total_files = 100,
+	};
+	int ret;
+	int c;
+
+	opts.seed = random64();
+	opts.nr_writers = sysconf(_SC_NPROCESSORS_ONLN);
+
+        while ((c = getopt(argc, argv, "b:d:f:m:n:rs:w:")) != -1) {
+                switch(c) {
+                case 'b':
+			ret = parse_u64(optarg, &opts.write_batch);
+			error_exit(ret, "error parsing -b '%s'\n", optarg);
+			error_exit(opts.write_batch == 0, "-b can't be 0");
+                        break;
+                case 'd':
+			ret = parse_low_high(optarg, &opts.low_dirs, &opts.high_dirs);
+			error_exit(ret, "error parsing -d '%s'\n", optarg);
+                        break;
+                case 'f':
+			ret = parse_low_high(optarg, &opts.low_files, &opts.high_files);
+			error_exit(ret, "error parsing -f '%s'\n", optarg);
+                        break;
+                case 'm':
+                        opts.meta_path = strdup(optarg);
+                        break;
+                case 'n':
+			ret = parse_u64(optarg, &opts.total_files);
+			error_exit(ret, "error parsing -n '%s'\n", optarg);
+                        break;
+                case 'r':
+			opts.read_only = true;
+			break;
+                case 's':
+			ret = parse_u64(optarg, &opts.seed);
+			error_exit(ret, "error parsing -s '%s'\n", optarg);
+                        break;
+                case 'w':
+			ret = parse_u64(optarg, &opts.nr_writers);
+			error_exit(ret, "error parsing -w '%s'\n", optarg);
+                        break;
+                case '?':
+                        printf("Unknown option '%c'\n", optopt);
+                        usage();
+			exit(1);
+                }
+        }
+
+	error_exit(opts.low_dirs > opts.high_dirs, "LOW > HIGH in -d %llu:%llu",
+		   opts.low_dirs, opts.high_dirs);
+	error_exit(opts.low_files > opts.high_files, "LOW > HIGH in -f %llu:%llu",
+		   opts.low_files, opts.high_files);
+	error_exit(!opts.meta_path, "must specify metadata device path with -m");
+
+	printf("recreate with: -d %llu:%llu -f %llu:%llu -n %llu -s %llu -w %llu\n",
+		opts.low_dirs, opts.high_dirs, opts.low_files, opts.high_files,
+		opts.total_files, opts.seed, opts.nr_writers);
+
+	ret = do_restore(&opts);
+
+	free(opts.meta_path);
+
+	return ret == 0 ? 0 : 1;
+}

--- a/tests/src/parallel_restore.c
+++ b/tests/src/parallel_restore.c
@@ -220,6 +220,9 @@ static struct gen_inode *generate_inode(struct opts *opts, u64 ino, mode_t mode)
 
 		gino->nr_xattrs = nr;
 		gino->inode.nr_xattrs = nr;
+
+		gino->inode.size = 4096;
+		gino->inode.offline = true;
 	}
 
 	return gino;

--- a/tests/src/restore_copy.c
+++ b/tests/src/restore_copy.c
@@ -1,0 +1,817 @@
+#define _GNU_SOURCE /* O_DIRECT */
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/xattr.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <ctype.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <time.h>
+#include <sys/prctl.h>
+#include <sys/socket.h>
+#include <sys/signal.h>
+#include <sys/statfs.h>
+#include <dirent.h>
+
+#include "../../utils/src/sparse.h"
+#include "../../utils/src/util.h"
+#include "../../utils/src/list.h"
+#include "../../utils/src/parse.h"
+#include "../../kmod/src/format.h"
+#include "../../kmod/src/ioctl.h"
+#include "../../utils/src/parallel_restore.h"
+
+/*
+ * XXX:
+ */
+
+#define ERRF " errno %d (%s)"
+#define ERRA errno, strerror(errno)
+
+#define error_exit(cond, fmt, args...)			\
+do {							\
+	if (cond) {					\
+		printf("error: "fmt"\n", ##args);	\
+		exit(1);				\
+	}						\
+} while (0)
+
+#define REG_MODE (S_IFREG | 0644)
+#define DIR_MODE (S_IFDIR | 0755)
+#define LNK_MODE (S_IFLNK | 0777)
+
+/*
+ * At about 1k files we seem to be writing about 1MB of data, so
+ * set buffer sizes adequately above that.
+ */
+#define BATCH_FILES 1024
+#define BUF_SIZ 2 * 1024 * 1024
+
+/*
+ * We can't make duplicate inodes for hardlinked files, so we
+ * will need to track these as we generate them. Not too costly
+ * to do, since it's just an integer, and sorting shouldn't matter
+ * until we get into the millions of entries, hopefully.
+ */
+static struct list_head hardlinks;
+struct hardlink_head {
+	struct list_head head;
+	u64 ino;
+};
+
+struct opts {
+	char *meta_path;
+	char *source_dir;
+};
+
+static bool warn_scoutfs = false;
+
+static void usage(void)
+{
+	printf("usage:\n"
+	       " -m PATH     | path to metadata device\n"
+	       " -s PATH     | path to source directory\n"
+	       );
+}
+
+static size_t write_bufs(struct scoutfs_parallel_restore_writer *wri,
+			 void *buf, int dev_fd)
+{
+	size_t total = 0;
+	size_t count;
+	off_t off;
+	int ret;
+
+	do {
+		ret = scoutfs_parallel_restore_write_buf(wri, buf, BUF_SIZ, &off, &count);
+		error_exit(ret, "write buf %d", ret);
+
+		if (count > 0) {
+			ret = pwrite(dev_fd, buf, count, off);
+			error_exit(ret != count, "pwrite count %zu ret %d", count, ret);
+			total += ret;
+		}
+	} while (count > 0);
+
+	return total;
+}
+
+struct write_result {
+	struct scoutfs_parallel_restore_progress prog;
+	struct scoutfs_parallel_restore_slice slice;
+	__le64 files_created;
+	__le64 dirs_created;
+	__le64 bytes_written;
+	bool complete;
+};
+
+static void write_bufs_and_send(struct scoutfs_parallel_restore_writer *wri,
+				void *buf, int dev_fd,
+				struct write_result *res, bool get_slice, int pair_fd)
+{
+	size_t total;
+	int ret;
+
+	total = write_bufs(wri, buf, dev_fd);
+	le64_add_cpu(&res->bytes_written, total);
+
+	ret = scoutfs_parallel_restore_get_progress(wri, &res->prog);
+	error_exit(ret, "get prog %d", ret);
+
+	if (get_slice) {
+		ret = scoutfs_parallel_restore_get_slice(wri, &res->slice);
+		error_exit(ret, "thread get slice %d", ret);
+	}
+
+	ret = write(pair_fd, res, sizeof(struct write_result));
+	error_exit(ret != sizeof(struct write_result), "result send error");
+
+	memset(res, 0, sizeof(struct write_result));
+}
+
+/*
+ * Adding xattrs is supported for files and directories only.
+ *
+ * If the filesystem on which the path resides isn't scoutfs, we omit the
+ * scoutfs specific ioctl to fetch hidden xattrs.
+ *
+ * Untested if the hidden xattr ioctl works on directories or symlinks.
+ */
+static void add_xattrs(struct scoutfs_parallel_restore_writer *wri, char *path, u64 ino, bool is_scoutfs)
+{
+	struct scoutfs_ioctl_listxattr_hidden lxh;
+	struct scoutfs_parallel_restore_xattr *xattr;
+	char *buf = NULL;
+	char *name = NULL;
+	int fd = -1;
+	int bytes;
+	int len;
+	int value_len;
+	int ret;
+	int pos = 0;
+
+	if (!is_scoutfs)
+		goto normal_xattrs;
+
+	fd = open(path, O_RDONLY);
+	error_exit(fd < 0, "open"ERRF, ERRA);
+
+	memset(&lxh, 0, sizeof(lxh));
+	lxh.id_pos = 0;
+	lxh.hash_pos = 0;
+	lxh.buf_bytes = 256 * 1024;
+
+	buf = malloc(lxh.buf_bytes);
+	error_exit(!buf, "alloc xattr_hidden buf");
+	lxh.buf_ptr = (unsigned long)buf;
+
+	/* hidden */
+	for (;;) {
+		ret = ioctl(fd, SCOUTFS_IOC_LISTXATTR_HIDDEN, &lxh);
+		if (ret == 0) /* done */
+			break;
+		error_exit(ret < 0, "listxattr_hidden"ERRF, ERRA);
+		bytes = ret;
+		error_exit(bytes > lxh.buf_bytes, "listxattr_hidden overflow");
+		error_exit(buf[bytes - 1] != '\0', "listxattr_hidden didn't term");
+
+		name = buf;
+
+		do {
+			len = strlen(name);
+			error_exit(len == 0, "listxattr_hidden empty name");
+			error_exit(len > SCOUTFS_XATTR_MAX_NAME_LEN, "listxattr_hidden long name");
+
+			/* get value len */
+			value_len = fgetxattr(fd, name, NULL, 0);
+			error_exit(value_len < 0, "malloc value hidden"ERRF, ERRA);
+
+			/* allocate everything at once */
+			xattr = malloc(sizeof(struct scoutfs_parallel_restore_xattr) + len + value_len);
+			error_exit(!xattr, "error allocating generated xattr");
+
+			*xattr = (struct scoutfs_parallel_restore_xattr) {
+				.ino = ino,
+				.pos = pos++,
+				.name_len = len,
+				.value_len = value_len,
+			};
+			xattr->name = (void *)(xattr + 1);
+			xattr->value = (void *)(xattr->name + len);
+
+			/* get value into xattr directly */
+			ret = fgetxattr(fd, name, (void *)(xattr->name + len), value_len);
+			error_exit(ret != value_len, "fgetxattr value"ERRF, ERRA);
+
+			memcpy(xattr->name, name, len);
+
+			ret = scoutfs_parallel_restore_add_xattr(wri, xattr);
+			error_exit(ret, "add hidden xattr %d", ret);
+
+			free(xattr);
+
+			name += len + 1;
+			bytes -= len + 1;
+		} while (bytes > 0);
+	}
+
+	free(buf);
+	close(fd);
+
+normal_xattrs:
+	value_len = listxattr(path, NULL, 0);
+	error_exit(value_len < 0, "hidden listxattr "ERRF, ERRA);
+	if (value_len == 0)
+		return;
+
+	buf = calloc(1, value_len);
+	error_exit(!buf, "malloc value"ERRF, ERRA);
+
+	ret = listxattr(path, buf, value_len);
+	error_exit(ret < 0, "hidden listxattr %d", ret);
+
+	name = buf;
+	bytes = ret;
+	do {
+		len = strlen(name);
+
+		error_exit(len == 0, "listxattr_hidden empty name");
+		error_exit(len > SCOUTFS_XATTR_MAX_NAME_LEN, "listxattr_hidden long name");
+
+		value_len = getxattr(path, name, NULL, 0);
+		error_exit(value_len < 0, "value "ERRF, ERRA);
+
+		xattr = malloc(sizeof(struct scoutfs_parallel_restore_xattr) + len + value_len);
+		error_exit(!xattr, "error allocating generated xattr");
+
+		*xattr = (struct scoutfs_parallel_restore_xattr) {
+			.ino = ino,
+			.pos = pos++,
+			.name_len = len,
+			.value_len = value_len,
+		};
+		xattr->name = (void *)(xattr + 1);
+		xattr->value = (void *)(xattr->name + len);
+
+		ret = getxattr(path, name, (void *)(xattr->name + len), value_len);
+		error_exit(ret != value_len, "fgetxattr value"ERRF, ERRA);
+
+		memcpy(xattr->name, name, len);
+
+		ret = scoutfs_parallel_restore_add_xattr(wri, xattr);
+		error_exit(ret, "add xattr %d", ret);
+
+		free(xattr);
+
+		name += len + 1;
+		bytes -= len + 1;
+	} while (bytes > 0);
+
+	free(buf);
+}
+
+/*
+ * We can't store the same inode multiple times, so we need to make
+ * sure to account for hardlinks. Maintain a LL that stores the first
+ * hardlink inode we encounter, and every subsequent hardlink to this
+ * inode will omit inserting an inode, and just adds another entry
+ */
+static bool is_new_inode_item(bool nlink, u64 ino)
+{
+	struct hardlink_head *hh_tmp;
+	struct hardlink_head *hh;
+
+	if (!nlink)
+		return true;
+
+	/* lineair search, pretty awful, should be a binary tree */
+	list_for_each_entry_safe(hh, hh_tmp, &hardlinks, head) {
+		if (hh->ino == ino)
+			return false;
+	}
+
+	/* insert item */
+	hh = malloc(sizeof(struct hardlink_head));
+	error_exit(!hh, "malloc");
+	hh->ino = ino;
+	list_add_tail(&hh->head, &hardlinks);
+
+	/*
+	 *  XXX
+	 *
+	 * We can be confident that if we don't traverse filesystems
+	 * that once we've created N entries of an N-linked inode, that
+	 * it can be removed from the LL. This would significantly
+	 * improve the manageability of the list.
+	 *
+	 * All we'd need to do is add a counter and compare it to the nr_links
+	 * field of the inode.
+	 */
+
+	return true;
+}
+
+/*
+ * create the inode data for a given path as best as possible
+ * duplicating the exact data from the source path
+ */
+static struct scoutfs_parallel_restore_inode *read_inode_data(char *path, u64 ino, bool *nlink, bool is_scoutfs)
+{
+	struct scoutfs_parallel_restore_inode *inode = NULL;
+	struct scoutfs_ioctl_stat_more stm;
+	struct stat st;
+	int ret;
+	int fd;
+
+	inode = calloc(1, sizeof(struct scoutfs_parallel_restore_inode));
+	error_exit(!inode, "failure allocating inode");
+
+	ret = lstat(path, &st);
+	error_exit(ret, "failure stat inode");
+
+	/* use exact inode numbers from path, except for root ino */
+	if (ino != SCOUTFS_ROOT_INO)
+		inode->ino = st.st_ino;
+	else
+		inode->ino = SCOUTFS_ROOT_INO;
+
+	inode->mode = st.st_mode;
+	inode->uid = st.st_uid;
+	inode->gid = st.st_gid;
+	inode->atime = st.st_atim;
+	inode->ctime = st.st_ctim;
+	inode->mtime = st.st_mtim;
+	inode->size = st.st_size;
+
+	inode->rdev = st.st_rdev;
+
+	/* scoutfs specific */
+	inode->meta_seq = 0;
+	inode->data_seq = 0;
+	inode->crtime = st.st_ctim;
+
+	if (S_ISREG(inode->mode)) {
+		if (inode->size > 0)
+			inode->offline = true;
+
+		if (is_scoutfs) {
+			fd = open(path, O_RDONLY);
+			error_exit(!fd, "open failure"ERRF, ERRA);
+
+			ret = ioctl(fd, SCOUTFS_IOC_STAT_MORE, &stm);
+			error_exit(ret, "failure SCOUTFS_IOC_STAT_MORE inode");
+
+			inode->meta_seq = stm.meta_seq;
+			inode->data_seq = stm.data_seq;
+			inode->crtime = (struct timespec){.tv_sec = stm.crtime_sec, .tv_nsec = stm.crtime_nsec};
+
+			close(fd);
+		}
+
+	}
+
+	/* pass whether item is hardlinked or not */
+	*nlink = (st.st_nlink > 1);
+
+	return inode;
+}
+
+struct writer_args {
+	struct list_head head;
+
+	int dev_fd;
+	int pair_fd;
+
+	struct scoutfs_parallel_restore_slice slice;
+};
+
+static void restore_path(struct scoutfs_parallel_restore_writer *wri, struct writer_args *args, struct write_result *res, void *buf, char *path, u64 ino)
+{
+	struct scoutfs_parallel_restore_inode *inode;
+	struct scoutfs_parallel_restore_entry *entry;
+	DIR *dirp = NULL;
+	char *subdir = NULL;
+	char link[PATH_MAX + 1];
+	struct dirent *ent;
+	struct statfs stf;
+	int ret = 0;
+	int subdir_count = 0, file_count = 0;
+	size_t ent_len = 0;
+	size_t pos = 0;
+	bool nlink = false;
+	char ind = '?';
+	u64 mode;
+	bool is_scoutfs = false;
+
+	/* get fs info once per path */
+	ret = statfs(path, &stf);
+	error_exit(ret != 0, "statfs"ERRF, ERRA);
+	is_scoutfs = (stf.f_type == 0x554f4353);
+
+	if (!is_scoutfs && !warn_scoutfs) {
+		warn_scoutfs = true;
+		fprintf(stderr, "Non-scoutfs source path detected: scoutfs specific features disabled\n");
+	}
+
+	/* traverse the entire tree */
+	dirp = opendir(path);
+	errno = 0;
+	while ((ent = readdir(dirp))) {
+		if (ent->d_type == DT_DIR) {
+			if ((strcmp(ent->d_name, ".") == 0) ||
+			    (strcmp(ent->d_name, "..") == 0)) {
+				/* position still matters */
+				pos++;
+				continue;
+			}
+
+			/* recurse into subdir */
+			ret = asprintf(&subdir, "%s/%s", path, ent->d_name);
+			error_exit(ret == -1, "asprintf subdir"ERRF, ERRA);
+			restore_path(wri, args, res, buf, subdir, ent->d_ino);
+
+			subdir_count++;
+
+			ent_len += strlen(ent->d_name);
+
+			entry = malloc(sizeof(struct scoutfs_parallel_restore_entry) + strlen(ent->d_name));
+			error_exit(!entry, "error allocating generated entry");
+
+			*entry = (struct scoutfs_parallel_restore_entry) {
+				.dir_ino = ino,
+				.pos = pos++,
+				.ino = ent->d_ino,
+				.mode = DIR_MODE,
+				.name = (void *)(entry + 1),
+				.name_len = strlen(ent->d_name),
+			};
+
+			memcpy(entry->name, ent->d_name, strlen(ent->d_name));
+			ret = scoutfs_parallel_restore_add_entry(wri, entry);
+			error_exit(ret, "add entry %d", ret);
+			free(entry);
+
+			add_xattrs(wri, subdir, ent->d_ino, is_scoutfs);
+
+			free(subdir);
+
+			le64_add_cpu(&res->dirs_created, 1);
+		} else if (ent->d_type == DT_REG) {
+
+			file_count++;
+
+			ent_len += strlen(ent->d_name);
+
+			entry = malloc(sizeof(struct scoutfs_parallel_restore_entry) + strlen(ent->d_name));
+			error_exit(!entry, "error allocating generated entry");
+
+			*entry = (struct scoutfs_parallel_restore_entry) {
+				.dir_ino = ino,
+				.pos = pos++,
+				.ino = ent->d_ino,
+				.mode = REG_MODE,
+				.name = (void *)(entry + 1),
+				.name_len = strlen(ent->d_name),
+			};
+
+			memcpy(entry->name, ent->d_name, strlen(ent->d_name));
+			ret = scoutfs_parallel_restore_add_entry(wri, entry);
+			error_exit(ret, "add entry %d", ret);
+			free(entry);
+
+			ret = asprintf(&subdir, "%s/%s", path, ent->d_name);
+			error_exit(ret == -1, "asprintf subdir"ERRF, ERRA);
+
+			/* file inode */
+			inode = read_inode_data(subdir, ent->d_ino, &nlink, is_scoutfs);
+			fprintf(stdout, "f %s/%s\n", path, ent->d_name);
+			if (is_new_inode_item(nlink, ent->d_ino)) {
+				ret = scoutfs_parallel_restore_add_inode(wri, inode);
+				error_exit(ret, "add reg file inode %d", ret);
+
+				/* xattrs */
+				add_xattrs(wri, subdir, ent->d_ino, is_scoutfs);
+			}
+			free(inode);
+
+			free(subdir);
+
+			le64_add_cpu(&res->files_created, 1);
+		} else if (ent->d_type == DT_LNK) {
+			/* readlink */
+
+			ret = asprintf(&subdir, "%s/%s", path, ent->d_name);
+			error_exit(ret == -1, "asprintf subdir"ERRF, ERRA);
+
+			ent_len += strlen(ent->d_name);
+
+			ret = readlink(subdir, link, PATH_MAX);
+			error_exit(ret < 0, "readlink %d", ret);
+			/* must 0-terminate if we want to print it */
+			link[ret] = 0;
+
+			entry = malloc(sizeof(struct scoutfs_parallel_restore_entry) + strlen(ent->d_name));
+			error_exit(!entry, "error allocating generated entry");
+
+			*entry = (struct scoutfs_parallel_restore_entry) {
+				.dir_ino = ino,
+				.pos = pos++,
+				.ino = ent->d_ino,
+				.mode = LNK_MODE,
+				.name = (void *)(entry + 1),
+				.name_len = strlen(ent->d_name),
+			};
+
+			memcpy(entry->name, ent->d_name, strlen(ent->d_name));
+			ret = scoutfs_parallel_restore_add_entry(wri, entry);
+			error_exit(ret, "add symlink entry %d", ret);
+
+			/* link inode */
+			inode = read_inode_data(subdir, ent->d_ino, &nlink, is_scoutfs);
+
+			fprintf(stdout, "l %s/%s -> %s\n", path, ent->d_name, link);
+
+			inode->mode = LNK_MODE;
+			inode->target = link;
+			inode->target_len = strlen(link) + 1; /* scoutfs null terminates symlinks */
+
+			ret = scoutfs_parallel_restore_add_inode(wri, inode);
+			error_exit(ret, "add syml inode %d", ret);
+
+			free(inode);
+			free(subdir);
+
+			le64_add_cpu(&res->files_created, 1);
+		} else {
+			/* odd stuff */
+			switch(ent->d_type) {
+			case DT_CHR:
+				ind = 'c';
+				mode = S_IFCHR;
+				break;
+			case DT_BLK:
+				ind = 'b';
+				mode = S_IFBLK;
+				break;
+			case DT_FIFO:
+				ind = 'p';
+				mode = S_IFIFO;
+				break;
+			case DT_SOCK:
+				ind = 's';
+				mode = S_IFSOCK;
+				break;
+			default:
+				error_exit(true, "Unknown readdir entry type");
+				;;
+			}
+
+			file_count++;
+
+			ent_len += strlen(ent->d_name);
+
+			entry = malloc(sizeof(struct scoutfs_parallel_restore_entry) + strlen(ent->d_name));
+			error_exit(!entry, "error allocating generated entry");
+
+			*entry = (struct scoutfs_parallel_restore_entry) {
+				.dir_ino = ino,
+				.pos = pos++,
+				.ino = ent->d_ino,
+				.mode = mode,
+				.name = (void *)(entry + 1),
+				.name_len = strlen(ent->d_name),
+			};
+
+			memcpy(entry->name, ent->d_name, strlen(ent->d_name));
+			ret = scoutfs_parallel_restore_add_entry(wri, entry);
+			error_exit(ret, "add entry %d", ret);
+
+			free(entry);
+
+			ret = asprintf(&subdir, "%s/%s", path, ent->d_name);
+			error_exit(ret == -1, "asprintf subdir"ERRF, ERRA);
+
+			/* file inode */
+			inode = read_inode_data(subdir, ent->d_ino, &nlink, is_scoutfs);
+			fprintf(stdout, "%c %lld %s/%s\n", ind, inode->ino, path, ent->d_name);
+			if (is_new_inode_item(nlink, ent->d_ino)) {
+				ret = scoutfs_parallel_restore_add_inode(wri, inode);
+				error_exit(ret, "add reg file inode %d", ret);
+			}
+			free(inode);
+
+			free(subdir);
+
+			le64_add_cpu(&res->files_created, 1);
+		}
+
+		/* batch out changes, will be about 1M */
+		if (le64_to_cpu(res->files_created) > BATCH_FILES) {
+			write_bufs_and_send(wri, buf, args->dev_fd, res, false, args->pair_fd);
+		}
+
+	}
+	if (ent != NULL)
+		error_exit(errno, "readdir"ERRF, ERRA);
+	closedir(dirp);
+
+	/* create the dir itself */
+	inode = read_inode_data(path, ino, &nlink, is_scoutfs);
+	inode->nr_subdirs = subdir_count;
+	inode->total_entry_name_bytes = ent_len;
+	fprintf(stdout, "d %s\n", path);
+
+	ret = scoutfs_parallel_restore_add_inode(wri, inode);
+	error_exit(ret, "add dir inode %d", ret);
+
+	free(inode);
+
+	/* No need to send, we'll send final after last directory is complete */
+}
+
+static int do_restore(struct opts *opts)
+{
+	struct scoutfs_parallel_restore_writer *pwri, *wri = NULL;
+	struct scoutfs_parallel_restore_slice *slices = NULL;
+	struct scoutfs_super_block *super = NULL;
+	struct writer_args *args;
+	struct write_result res;
+	int pair[2] = {-1, -1};
+	LIST_HEAD(writers);
+	void *buf = NULL;
+	void *bufp = NULL;
+	int dev_fd = -1;
+	pid_t pid;
+	int ret;
+	u64 tot_bytes;
+	u64 tot_dirs;
+	u64 tot_files;
+
+	ret = socketpair(PF_LOCAL, SOCK_STREAM, 0, pair);
+	error_exit(ret, "socketpair error "ERRF, ERRA);
+
+	dev_fd = open(opts->meta_path, O_DIRECT | (O_RDWR|O_EXCL));
+	error_exit(dev_fd < 0, "error opening '%s': "ERRF, opts->meta_path, ERRA);
+
+	errno = posix_memalign((void **)&super, 4096, SCOUTFS_BLOCK_SM_SIZE) ?:
+		posix_memalign((void **)&buf, 4096, BUF_SIZ);
+	error_exit(errno, "error allocating block bufs "ERRF, ERRA);
+
+	ret = pread(dev_fd, super, SCOUTFS_BLOCK_SM_SIZE,
+		    SCOUTFS_SUPER_BLKNO << SCOUTFS_BLOCK_SM_SHIFT);
+	error_exit(ret != SCOUTFS_BLOCK_SM_SIZE, "error reading super, ret %d", ret);
+
+	error_exit((super->flags & SCOUTFS_FLAG_IS_META_BDEV) == 0, "super block is not meta dev");
+
+	ret = scoutfs_parallel_restore_create_writer(&wri);
+	error_exit(ret, "create writer %d", ret);
+
+	ret = scoutfs_parallel_restore_import_super(wri, super);
+	error_exit(ret, "import super %d", ret);
+
+	slices = calloc(2, sizeof(struct scoutfs_parallel_restore_slice));
+	error_exit(!slices, "alloc slices");
+
+	scoutfs_parallel_restore_init_slices(wri, slices, 2);
+
+	ret = scoutfs_parallel_restore_add_slice(wri, &slices[0]);
+	error_exit(ret, "add slices[0] %d", ret);
+
+	args = calloc(1, sizeof(struct writer_args));
+	error_exit(!args, "alloc writer args");
+
+	args->dev_fd = dev_fd;
+	args->slice = slices[1];
+	args->pair_fd = pair[1];
+	list_add_tail(&args->head, &writers);
+
+	/* fork writer process */
+	pid = fork();
+	error_exit(pid == -1, "fork error");
+
+	if (pid == 0) {
+		ret = prctl(PR_SET_PDEATHSIG, SIGHUP);
+		error_exit(ret < 0, "failed to set parent death sig");
+
+		errno = posix_memalign((void **)&bufp, 4096, BUF_SIZ);
+		error_exit(errno, "error allocating block bufp "ERRF, ERRA);
+
+		ret = scoutfs_parallel_restore_create_writer(&pwri);
+		error_exit(ret, "create pwriter %d", ret);
+
+		ret = scoutfs_parallel_restore_add_slice(pwri, &args->slice);
+		error_exit(ret, "add pslice %d", ret);
+
+		memset(&res, 0, sizeof(res));
+
+		restore_path(pwri, args, &res, bufp, opts->source_dir, SCOUTFS_ROOT_INO);
+
+		res.complete = true;
+
+		write_bufs_and_send(pwri, buf, args->dev_fd, &res, true, args->pair_fd);
+
+		scoutfs_parallel_restore_destroy_writer(&pwri);
+		free(bufp);
+
+		exit(0);
+	};
+
+	/* read results and wait for writer to finish */
+	tot_bytes = 0;
+	tot_dirs = 1;
+	tot_files = 0;
+	for (;;) {
+		ret = read(pair[0], &res, sizeof(struct write_result));
+		error_exit(ret != sizeof(struct write_result), "result read error %d", ret);
+
+		ret = scoutfs_parallel_restore_add_progress(wri, &res.prog);
+		error_exit(ret, "add thr prog %d", ret);
+
+		if (res.slice.meta_len != 0) {
+			ret = scoutfs_parallel_restore_add_slice(wri, &res.slice);
+			error_exit(ret, "add thr slice %d", ret);
+
+			if (res.complete)
+				break;
+		}
+
+		tot_bytes += le64_to_cpu(res.bytes_written);
+		tot_files += le64_to_cpu(res.files_created);
+		tot_dirs += le64_to_cpu(res.dirs_created);
+	}
+
+	tot_bytes += write_bufs(wri, buf, args->dev_fd);
+
+	fprintf(stdout, "Wrote %lld directories, %lld files, %lld bytes total\n",
+		tot_dirs, tot_files, tot_bytes);
+
+	/* write super to finalize */
+	ret = scoutfs_parallel_restore_export_super(wri, super);
+	error_exit(ret, "update super %d", ret);
+
+	ret = pwrite(dev_fd, super, SCOUTFS_BLOCK_SM_SIZE,
+		     SCOUTFS_SUPER_BLKNO << SCOUTFS_BLOCK_SM_SHIFT);
+	error_exit(ret != SCOUTFS_BLOCK_SM_SIZE, "error writing super, ret %d", ret);
+
+	scoutfs_parallel_restore_destroy_writer(&wri);
+
+	if (dev_fd >= 0)
+		close(dev_fd);
+	if (pair[0] > 0)
+		close(pair[0]);
+	if (pair[1] > 0)
+		close(pair[1]);
+	free(super);
+	free(args);
+	free(slices);
+	free(buf);
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	struct opts opts = (struct opts){ 0 };
+	struct hardlink_head *hh_tmp;
+	struct hardlink_head *hh;
+	int ret;
+	int c;
+
+	INIT_LIST_HEAD(&hardlinks);
+
+        while ((c = getopt(argc, argv, "b:m:s:")) != -1) {
+                switch(c) {
+                case 'm':
+                        opts.meta_path = strdup(optarg);
+                        break;
+		case 's':
+			opts.source_dir = strdup(optarg);
+			break;
+                case '?':
+                        printf("Unknown option '%c'\n", optopt);
+                        usage();
+			exit(1);
+                }
+        }
+
+	error_exit(!opts.meta_path, "must specify metadata device path with -m");
+	error_exit(!opts.source_dir, "must specify source directory path with -s");
+
+	ret = do_restore(&opts);
+
+	free(opts.meta_path);
+	free(opts.source_dir);
+
+	list_for_each_entry_safe(hh, hh_tmp, &hardlinks, head) {
+		list_del_init(&hh->head);
+		free(hh);
+	}
+
+	return ret == 0 ? 0 : 1;
+}

--- a/tests/tests/basic-posix-consistency.sh
+++ b/tests/tests/basic-posix-consistency.sh
@@ -3,13 +3,13 @@
 # operations in one mount and verify the results in another.
 #
 
-t_require_commands getfattr setfattr dd filefrag diff touch stat scoutfs
+t_require_commands getfattr setfattr dd filefrag-gc57857a5 diff touch stat scoutfs
 t_require_mounts 2
 
 GETFATTR="getfattr --absolute-names"
 SETFATTR="setfattr"
 DD="dd status=none"
-FILEFRAG="filefrag -v -b4096"
+FILEFRAG="filefrag-gc57857a5 -v -b4096"
 
 echo "== root inode updates flow back and forth"
 sleep 1

--- a/tests/tests/data-prealloc.sh
+++ b/tests/tests/data-prealloc.sh
@@ -4,7 +4,7 @@
 # merge adjacent consecutive allocations.  (we don't have multiple
 # allocation cursors)
 #
-t_require_commands scoutfs stat filefrag dd touch truncate
+t_require_commands scoutfs stat filefrag-gc57857a5 dd touch truncate
 
 write_block()
 {
@@ -76,7 +76,7 @@ print_extents_found()
 {
 	local prefix="$1"
 
-	filefrag "$prefix"* 2>&1 | grep "extent.*found" | t_filter_fs
+	filefrag-gc57857a5 "$prefix"* 2>&1 | grep "extent.*found" | t_filter_fs
 }
 
 #
@@ -86,7 +86,7 @@ print_logical_extents()
 {
 	local file="$1"
 
-	filefrag -v -b4096 "$file" 2>&1 | t_filter_fs | awk '
+	filefrag-gc57857a5 -v -b4096 "$file" 2>&1 | t_filter_fs | awk '
 		($1 ~ /[0-9]+:/) {
 			if ($NF !~  /[0-9]+:/) {
 				flags=$NF
@@ -95,7 +95,7 @@ print_logical_extents()
 			}
 			print $2, $6, flags
 		}
-	' | sed 's/last,eof/eof/'
+	'
 }
 
 t_save_all_sysfs_mount_options data_prealloc_blocks

--- a/tests/tests/parallel_restore.sh
+++ b/tests/tests/parallel_restore.sh
@@ -10,7 +10,7 @@ mkdir -p "$SCR"
 # XXX this is all pretty manual, would be nice to have helpers
 echo "== make small meta fs"
 # meta device just big enough for reserves and the metadata we'll fill
-scoutfs mkfs -A -f -Q 0,127.0.0.1,53000 -m 10G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
+scoutfs mkfs -A -f -Q 0,127.0.0.1,53000 -m 10G -d 60G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
 	t_fail "mkfs failed"
 mount -t scoutfs -o metadev_path=$T_EX_META_DEV,quorum_slot_nr=0 \
 	"$T_EX_DATA_DEV" "$SCR"
@@ -31,12 +31,13 @@ scoutfs statfs -p "$SCR" | grep -v -e 'fsid' -e 'rid'
 find "$SCR" -exec scoutfs list-hidden-xattrs {} \; | wc
 scoutfs search-xattrs -p "$SCR" scoutfs.hide.srch.sam_vol_F01030L6 -p "$SCR" | wc
 find "$SCR" -type f -name "file-*" | head -n 4 | xargs -n 1 filefrag-gc57857a5 -b4096 -v | grep -e ext: -e eof
+scoutfs df -p "$SCR"
 
 echo "== unmount small meta fs"
 umount "$SCR"
 
 echo "== ENOSPC"
-scoutfs mkfs -A -f -Q 0,127.0.0.1,53000 -m 10G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
+scoutfs mkfs -A -f -Q 0,127.0.0.1,53000 -m 10G -d 60G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
 	t_fail "mkfs failed"
 parallel_restore -m "$T_EX_META_DEV" -d 600:1000 -f 600:1000 -n 4000000 | grep died 2>&1 && t_fail "parallel_restore"
 

--- a/tests/tests/parallel_restore.sh
+++ b/tests/tests/parallel_restore.sh
@@ -1,0 +1,44 @@
+#
+# validate parallel restore library
+#
+
+t_require_commands scoutfs parallel_restore
+
+SCR="$T_TMPDIR/mnt.scratch"
+mkdir -p "$SCR"
+
+# XXX this is all pretty manual, would be nice to have helpers
+echo "== make small meta fs"
+# meta device just big enough for reserves and the metadata we'll fill
+scoutfs mkfs -A -f -Q 0,127.0.0.1,53000 -m 10G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
+	t_fail "mkfs failed"
+mount -t scoutfs -o metadev_path=$T_EX_META_DEV,quorum_slot_nr=0 \
+	"$T_EX_DATA_DEV" "$SCR"
+umount "$SCR"
+
+echo "== parallel_restore"
+parallel_restore -m "$T_EX_META_DEV" > /dev/null || t_fail "parallel_restore"
+
+echo "== mount restored filesystem"
+mount -t scoutfs -o metadev_path=$T_EX_META_DEV,quorum_slot_nr=0 \
+	"$T_EX_DATA_DEV" "$SCR"
+
+#
+# This is pretty crude...
+#
+echo "== compare filesystem contents"
+scoutfs statfs -p "$SCR" | grep -v -e 'fsid' -e 'rid'
+find "$SCR" -exec scoutfs list-hidden-xattrs {} \; | wc
+scoutfs search-xattrs -p "$SCR" scoutfs.hide.srch.sam_vol_F01030L6 -p "$SCR" | wc
+
+echo "== unmount small meta fs"
+umount "$SCR"
+
+echo "== ENOSPC"
+scoutfs mkfs -A -f -Q 0,127.0.0.1,53000 -m 10G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
+	t_fail "mkfs failed"
+parallel_restore -m "$T_EX_META_DEV" -d 600:1000 -f 600:1000 -n 4000000 | grep died 2>&1 && t_fail "parallel_restore"
+
+echo "== cleanup"
+rmdir "$SCR"
+t_pass

--- a/tests/tests/parallel_restore.sh
+++ b/tests/tests/parallel_restore.sh
@@ -2,7 +2,7 @@
 # validate parallel restore library
 #
 
-t_require_commands scoutfs parallel_restore
+t_require_commands scoutfs parallel_restore filefrag-gc57857a5 find xargs
 
 SCR="$T_TMPDIR/mnt.scratch"
 mkdir -p "$SCR"
@@ -30,6 +30,7 @@ echo "== compare filesystem contents"
 scoutfs statfs -p "$SCR" | grep -v -e 'fsid' -e 'rid'
 find "$SCR" -exec scoutfs list-hidden-xattrs {} \; | wc
 scoutfs search-xattrs -p "$SCR" scoutfs.hide.srch.sam_vol_F01030L6 -p "$SCR" | wc
+find "$SCR" -type f -name "file-*" | head -n 4 | xargs -n 1 filefrag-gc57857a5 -b4096 -v | grep -e ext: -e eof
 
 echo "== unmount small meta fs"
 umount "$SCR"

--- a/tests/tests/setattr_more.sh
+++ b/tests/tests/setattr_more.sh
@@ -2,7 +2,7 @@
 # Test correctness of the setattr_more ioctl.
 #
 
-t_require_commands filefrag scoutfs touch mkdir rm stat mknod
+t_require_commands filefrag-gc57857a5 scoutfs touch mkdir rm stat mknod
 
 FILE="$T_D0/file"
 
@@ -65,7 +65,7 @@ rm "$FILE"
 echo "== large offline extents are created"
 touch "$FILE"
 scoutfs setattr -V 1 -o -s $((10007 * 4096)) "$FILE" 2>&1 | t_filter_fs
-filefrag -v -b4096 "$FILE" 2>&1 | sed 's/last,unknown_loc,eof$/unknown,eof/' | t_filter_fs
+filefrag-gc57857a5 -v -b4096 "$FILE" 2>&1 | t_filter_fs
 rm "$FILE"
 
 # had a bug where we were creating extents that were too long

--- a/tests/tests/simple-release-extents.sh
+++ b/tests/tests/simple-release-extents.sh
@@ -2,11 +2,11 @@
 # Test that releasing extents creates offline extents.
 #
 
-t_require_commands xfs_io filefrag scoutfs mknod
+t_require_commands xfs_io filefrag-gc57857a5 scoutfs mknod
 
 # this test wants to ignore unwritten extents
 fiemap_file() {
-	filefrag -v -b4096 "$1" | grep -v "unwritten"
+	filefrag-gc57857a5 -v -b4096 "$1" | grep -v "unwritten"
 }
 
 create_file() {

--- a/tests/tests/simple-staging.sh
+++ b/tests/tests/simple-staging.sh
@@ -2,10 +2,10 @@
 # Test correctness of the staging operation
 #
 
-t_require_commands filefrag dd scoutfs cp cmp rm
+t_require_commands filefrag-gc57857a5 dd scoutfs cp cmp rm
 
 fiemap_file() {
-	filefrag -v -b4096 "$1"
+	filefrag-gc57857a5 -v -b4096 "$1"
 }
 
 create_file() {

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -18,7 +18,9 @@ BIN := src/scoutfs
 OBJ := $(patsubst %.c,%.o,$(wildcard src/*.c))
 DEPS := $(wildcard */*.d)
 
-all: $(BIN)
+AR := src/scoutfs_parallel_restore.a
+
+all: $(BIN) $(AR)
 
 ifneq ($(DEPS),)
 -include $(DEPS)
@@ -35,6 +37,10 @@ endif
 $(BIN): $(OBJ)
 	$(QU)  [BIN $@]
 	$(VE)gcc -o $@ $^ -luuid -lm -lcrypto -lblkid
+
+$(AR): $(OBJ)
+	$(QU)  [AR $@]
+	$(VE)ar rcs $@ $^
 
 %.o %.d: %.c Makefile sparse.sh
 	$(QU)  [CC $<]

--- a/utils/scoutfs-utils.spec.in
+++ b/utils/scoutfs-utils.spec.in
@@ -54,6 +54,8 @@ cp man/*.8.gz $RPM_BUILD_ROOT%{_mandir}/man8/.
 install -m 755 -D src/scoutfs $RPM_BUILD_ROOT%{_sbindir}/scoutfs
 install -m 644 -D src/ioctl.h $RPM_BUILD_ROOT%{_includedir}/scoutfs/ioctl.h
 install -m 644 -D src/format.h $RPM_BUILD_ROOT%{_includedir}/scoutfs/format.h
+install -m 644 -D src/parallel_restore.h $RPM_BUILD_ROOT%{_includedir}/scoutfs/parallel_restore.h
+install -m 644 -D src/scoutfs_parallel_restore.a $RPM_BUILD_ROOT%{_libdir}/scoutfs/libscoutfs_parallel_restore.a
 install -m 755 -D fenced/scoutfs-fenced $RPM_BUILD_ROOT%{_libexecdir}/scoutfs-fenced/scoutfs-fenced
 install -m 644 -D fenced/scoutfs-fenced.service $RPM_BUILD_ROOT%{_unitdir}/scoutfs-fenced.service
 install -m 644 -D fenced/scoutfs-fenced.conf.example $RPM_BUILD_ROOT%{_sysconfdir}/scoutfs/scoutfs-fenced.conf.example
@@ -70,6 +72,7 @@ install -m 644 -D fenced/scoutfs-fenced.conf.example $RPM_BUILD_ROOT%{_sysconfdi
 %files -n scoutfs-devel
 %defattr(644,root,root,755)
 %{_includedir}/scoutfs
+%{_libdir}/scoutfs
 
 %clean
 rm -rf %{buildroot}

--- a/utils/src/bloom.c
+++ b/utils/src/bloom.c
@@ -1,0 +1,20 @@
+#include <errno.h>
+
+#include "sparse.h"
+#include "util.h"
+#include "format.h"
+#include "hash.h"
+#include "bloom.h"
+
+void calc_bloom_nrs(struct scoutfs_key *key, unsigned int *nrs)
+{
+	u64 hash;
+	int i;
+
+	hash = scoutfs_hash64(key, sizeof(struct scoutfs_key));
+
+	for (i = 0; i < SCOUTFS_FOREST_BLOOM_NRS; i++) {
+		nrs[i] = (u32)hash % SCOUTFS_FOREST_BLOOM_BITS;
+		hash >>= SCOUTFS_FOREST_BLOOM_FUNC_BITS;
+	}
+}

--- a/utils/src/bloom.h
+++ b/utils/src/bloom.h
@@ -1,0 +1,6 @@
+#ifndef _BLOOM_H_
+#define _BLOOM_H_
+
+void calc_bloom_nrs(struct scoutfs_key *key, unsigned int *nrs);
+
+#endif

--- a/utils/src/btree.c
+++ b/utils/src/btree.c
@@ -8,7 +8,7 @@
 #include "leaf_item_hash.h"
 #include "btree.h"
 
-static void init_block(struct scoutfs_btree_block *bt, int level)
+void btree_init_block(struct scoutfs_btree_block *bt, int level)
 {
 	int free;
 
@@ -33,7 +33,7 @@ void btree_init_root_single(struct scoutfs_btree_root *root,
 
 	memset(bt, 0, SCOUTFS_BLOCK_LG_SIZE);
 
-	init_block(bt, 0);
+	btree_init_block(bt, 0);
 }
 
 static void *alloc_val(struct scoutfs_btree_block *bt, int len)

--- a/utils/src/btree.h
+++ b/utils/src/btree.h
@@ -1,6 +1,7 @@
 #ifndef _BTREE_H_
 #define _BTREE_H_
 
+void btree_init_block(struct scoutfs_btree_block *bt, int level);
 void btree_init_root_single(struct scoutfs_btree_root *root,
 			    struct scoutfs_btree_block *bt,
 			    u64 seq, u64 blkno);

--- a/utils/src/lk_rbtree_wrapper.h
+++ b/utils/src/lk_rbtree_wrapper.h
@@ -1,0 +1,24 @@
+#ifndef _LK_RBTREE_WRAPPER_H_
+#define _LK_RBTREE_WRAPPER_H_
+
+/*
+ * We're using this lame hack to build and use the kernel's rbtree in
+ * userspace.  We drop the kernel's rbtree*[ch] implementation in and
+ * use them with this wrapper.  We only have to remove the kernel
+ * includes from the imported files.
+ */
+
+#include <stdbool.h>
+#include "util.h"
+
+#define rcu_assign_pointer(a, b)	do { a = b; } while (0)
+#define READ_ONCE(a)			({ a; })
+#define WRITE_ONCE(a, b)		do { a = b; } while (0)
+#define unlikely(a)			({ a; })
+#define EXPORT_SYMBOL(a)		/* nop */
+
+#include "rbtree_types.h"
+#include "rbtree.h"
+#include "rbtree_augmented.h"
+
+#endif

--- a/utils/src/mode_types.c
+++ b/utils/src/mode_types.c
@@ -1,0 +1,24 @@
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "sparse.h"
+#include "util.h"
+#include "format.h"
+#include "mode_types.h"
+
+unsigned int mode_to_type(mode_t mode)
+{
+#define S_SHIFT 12
+	static unsigned char mode_types[S_IFMT >> S_SHIFT] = {
+		[S_IFIFO >> S_SHIFT]	= SCOUTFS_DT_FIFO,
+		[S_IFCHR >> S_SHIFT]	= SCOUTFS_DT_CHR,
+		[S_IFDIR >> S_SHIFT]	= SCOUTFS_DT_DIR,
+		[S_IFBLK >> S_SHIFT]	= SCOUTFS_DT_BLK,
+		[S_IFREG >> S_SHIFT]	= SCOUTFS_DT_REG,
+		[S_IFLNK >> S_SHIFT]	= SCOUTFS_DT_LNK,
+		[S_IFSOCK >> S_SHIFT]	= SCOUTFS_DT_SOCK,
+	};
+
+	return mode_types[(mode & S_IFMT) >> S_SHIFT];
+#undef S_SHIFT
+}

--- a/utils/src/mode_types.h
+++ b/utils/src/mode_types.h
@@ -1,0 +1,6 @@
+#ifndef _MODE_TYPES_H_
+#define _MODE_TYPES_H_
+
+unsigned int mode_to_type(mode_t mode);
+
+#endif

--- a/utils/src/name_hash.h
+++ b/utils/src/name_hash.h
@@ -1,0 +1,46 @@
+#ifndef _SCOUTFS_NAME_HASH_H_
+#define _SCOUTFS_NAME_HASH_H_
+
+#include "hash.h"
+
+/*
+ * Test a bit number as though an array of bytes is a large len-bit
+ * big-endian value.  nr 0 is the LSB of the final byte, nr (len - 1) is
+ * the MSB of the first byte.
+ */
+static int test_be_bytes_bit(int nr, const char *bytes, int len)
+{
+	return bytes[(len - 1 - nr) >> 3] & (1 << (nr & 7));
+}
+
+/*
+ * Generate a 32bit "fingerprint" of the name by extracting 32 evenly
+ * distributed bits from the name.  The intent is to have the sort order
+ * of the fingerprints reflect the memcmp() sort order of the names
+ * while mapping large names down to small fs keys.
+ *
+ * Names that are smaller than 32bits are biased towards the high bits
+ * of the fingerprint so that most significant bits of the fingerprints
+ * consistently reflect the initial characters of the names.
+ */
+static inline u32 dirent_name_fingerprint(const char *name, unsigned int name_len)
+{
+	int name_bits = name_len * 8;
+	int skip = max(name_bits / 32, 1);
+	u32 fp = 0;
+	int f;
+	int n;
+
+	for (f = 31, n = name_bits - 1; f >= 0 && n >= 0; f--, n -= skip)
+		fp |= !!test_be_bytes_bit(n, name, name_bits) << f;
+
+	return fp;
+}
+
+static inline u64 dirent_name_hash(const char *name, unsigned int name_len)
+{
+       return scoutfs_hash32(name, name_len) |
+              ((u64)dirent_name_fingerprint(name, name_len) << 32);
+}
+
+#endif

--- a/utils/src/parallel_restore.c
+++ b/utils/src/parallel_restore.c
@@ -522,6 +522,7 @@ static spr_err_t insert_extent_item(struct scoutfs_parallel_restore_writer *wri,
 
 	err = bti_alloc(sizeof(struct scoutfs_data_extent_val), &bti);
 	if (!err) {
+		bti->key = key;
 		dv = bti->val;
 		dv->blkno = 0;
 		dv->flags = SEF_OFFLINE;

--- a/utils/src/parallel_restore.c
+++ b/utils/src/parallel_restore.c
@@ -1,0 +1,1871 @@
+#include <unistd.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/time.h>
+#include <uuid/uuid.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <assert.h>
+#include <math.h>
+#include <sys/uio.h>
+
+#include "sparse.h"
+#include "util.h"
+#include "format.h"
+#include "crc.h"
+#include "rand.h"
+#include "key.h"
+#include "bitops.h"
+#include "btree.h"
+#include "leaf_item_hash.h"
+#include "name_hash.h"
+#include "mode_types.h"
+#include "srch.h"
+#include "bloom.h"
+
+#include "parallel_restore.h"
+
+#include "list.h"
+#include "lk_rbtree_wrapper.h"
+
+/*
+ * XXX
+ *  - interface versioning?
+ *  - next seq and next ino are both max ino + 1
+ *  - fix writer builder layout to match super, users except for build order
+ *  - look into zeroing buffers consistently
+ *  - init_alb looks weird?  naming consistency?
+ *  - make sure inode_count makes sense (fs root, log deltas)
+ *  - audit file types
+ */
+
+#define dprintf(fmt, args...)		\
+do {					\
+	if (0)				\
+		printf(fmt, ##args);	\
+} while (0)
+
+struct btree_item {
+	struct rb_node node;
+	struct scoutfs_key key;
+	unsigned int val_len;
+	void *val;
+};
+
+struct srch_node {
+	struct rb_node node;
+	u64 hash;
+	u64 ino;
+	u64 id;
+};
+
+struct block_builder;
+typedef bool (*bld_empty_t)(struct block_builder *bld);
+typedef void (*bld_reset_t)(struct block_builder *bld);
+typedef spr_err_t (*bld_build_t)(struct scoutfs_parallel_restore_writer *wri,
+				 struct block_builder *bld, void *buf, u64 blkno);
+typedef spr_err_t (*bld_post_t)(struct scoutfs_parallel_restore_writer *wri,
+				struct block_builder *bld);
+
+struct block_builder {
+	struct list_head head;
+	bld_empty_t empty;
+	bld_reset_t reset;
+	bld_build_t build;
+	bld_post_t post;
+};
+
+struct btree_builder {
+	struct block_builder bld;
+
+	/* track all items */
+	u64 total_items;
+	/* track total length of extent items */
+	u64 total_len;
+
+	/* eventual root that references built blocks */
+	struct scoutfs_btree_root btroot;
+
+	/* blocks are built as levels accumulate sufficient items */
+	struct {
+		struct rb_root root;
+		unsigned long nr;
+	} items[SCOUTFS_BTREE_MAX_HEIGHT];
+};
+
+struct alloc_list_builder {
+	struct block_builder bld;
+	u64 start;
+	u64 len;
+	struct scoutfs_alloc_list_head lhead;
+};
+
+/*
+ * srch parent radix fanout is really wide, it doesn't take many to have
+ * 2^64 bytes in entry blocks.
+ */
+#define MAX_SRCH_HEIGHT 6
+
+struct srch_builder {
+	struct block_builder bld;
+
+	/* accumulates blocks/entries as we build */
+	struct scoutfs_srch_file sfl;
+
+	/* no parents at level 0, [0] never used */
+	u64 total_parent_refs;
+	struct {
+		struct scoutfs_block_ref *refs;
+		unsigned long nr;
+	} parents[MAX_SRCH_HEIGHT];
+
+	struct rb_root entries;
+};
+
+struct bloom_builder {
+	struct block_builder bld;
+	struct scoutfs_bloom_block *bloom;
+};
+
+struct scoutfs_parallel_restore_writer {
+	u64 inode_count;
+	u64 max_ino;
+
+	__le64 fsid;
+	u64 meta_start;
+	u64 meta_len;
+	struct list_head meta_extents;
+
+	struct list_head builders;
+	struct btree_builder meta_btb[2];
+	struct btree_builder data_btb;
+	struct alloc_list_builder meta_alb[2];
+	struct btree_builder root_btb;
+	struct btree_builder fs_btb;
+	struct btree_builder srch_btb;
+	struct btree_builder log_btb;
+
+	struct srch_builder srch_sbld;
+	struct bloom_builder bloom_bbld;
+
+	struct scoutfs_btree_root root_items;
+	struct scoutfs_super_block super;
+};
+
+struct extent_head {
+	struct list_head head;
+	u64 start;
+	u64 len;
+};
+
+static void init_builder(struct block_builder *bld, bld_empty_t empty, bld_reset_t reset,
+			 bld_build_t build)
+{
+	INIT_LIST_HEAD(&bld->head);
+	bld->empty = empty;
+	bld->reset = reset;
+	bld->build = build;
+	bld->post = NULL;
+}
+
+static spr_err_t meta_alloc_add(struct scoutfs_parallel_restore_writer *wri,
+				u64 start, u64 len)
+{
+	struct extent_head *eh;
+
+	if (len == 0)
+		return 0;
+
+	if (wri->meta_len == 0) {
+		wri->meta_start = start;
+		wri->meta_len = len;
+	} else {
+		eh = malloc(sizeof(struct extent_head));
+		if  (!eh)
+			return ENOMEM;
+		eh->start = start;
+		eh->len = len;
+		list_add_tail(&eh->head, &wri->meta_extents);
+	}
+
+	return 0;
+}
+
+static spr_err_t meta_alloc_contig(struct scoutfs_parallel_restore_writer *wri,
+				   u64 prev, u64 *blkno_ret)
+{
+	struct extent_head *eh;
+
+	if (prev && wri->meta_len && (wri->meta_start != prev + 1)) {
+		*blkno_ret = 0;
+		return 0;
+	}
+
+	if (!wri->meta_len) {
+		*blkno_ret = 0;
+		return ENOSPC;
+	}
+
+	*blkno_ret = wri->meta_start++;
+
+	if (--wri->meta_len == 0 && !list_empty(&wri->meta_extents)) {
+		eh = list_entry(wri->meta_extents.next, struct extent_head, head);
+		wri->meta_start = eh->start;
+		wri->meta_len = eh->len;
+		free(eh);
+	}
+
+	return 0;
+}
+
+static spr_err_t bti_alloc(int val_len, struct btree_item **bti_ret)
+{
+	struct btree_item *bti;
+	spr_err_t err;
+
+	bti = malloc(sizeof(struct btree_item) + val_len);
+	if (bti) {
+		bti->val = (void *)(bti + 1);
+		bti->val_len = val_len;
+		err = 0;
+	} else {
+		err = ENOMEM;
+	}
+
+	*bti_ret = bti;
+	return err;
+}
+
+static struct btree_item *bti_walk(struct rb_root *root, struct scoutfs_key *key,
+				   struct btree_item *ins)
+{
+	struct rb_node **node = &root->rb_node;
+	struct rb_node *parent = NULL;
+	struct btree_item *found = NULL;
+	struct btree_item *bti;
+	int cmp;
+
+	while (*node) {
+		parent = *node;
+		bti = container_of(*node, struct btree_item, node);
+
+		cmp = scoutfs_key_compare(key, &bti->key);
+		if (cmp < 0) {
+			node = &(*node)->rb_left;
+		} else if (cmp > 0) {
+			node = &(*node)->rb_right;
+		} else {
+			found = bti;
+			break;
+		}
+	}
+
+	if (ins && !found) {
+		rb_link_node(&ins->node, parent, node);
+		rb_insert_color(&ins->node, root);
+	}
+
+	return found;
+}
+
+static struct btree_item *node_bti(struct rb_node *node)
+{
+	return node ? container_of(node, struct btree_item, node) : NULL;
+}
+
+static struct btree_item *bti_first(struct rb_root *root)
+{
+	return node_bti(rb_first(root));
+}
+
+static struct btree_item *bti_next(struct btree_item *bti)
+{
+	return bti ? node_bti(rb_next(&bti->node)) : NULL;
+}
+
+#define for_each_bti_safe(root, bti, tmp) \
+	for (bti = bti_first(root); bti && ((tmp = bti_next(bti)), 1); bti = tmp)
+
+/*
+ * It's always an error to try and insert a key that was already tracked
+ * in a btree level.
+ */
+static spr_err_t btb_insert(struct btree_builder *btb, struct btree_item *bti, int level)
+{
+	struct btree_item *found;
+
+	found = bti_walk(&btb->items[level].root, &bti->key, bti);
+	if (found) {
+		return EEXIST;
+	} else {
+		btb->items[level].nr++;
+		btb->total_items++;
+		return 0;
+	}
+}
+
+static void btb_erase(struct btree_builder *btb, struct btree_item *bti, int level)
+{
+	rb_erase(&bti->node, &btb->items[level].root);
+	btb->items[level].nr--;
+	btb->total_items--;
+}
+
+static void btb_destroy(struct btree_builder *btb)
+{
+	struct btree_item *bti;
+	struct btree_item *tmp;
+	int i;
+
+	for (i = 0; i < array_size(btb->items); i++) {
+		for_each_bti_safe(&btb->items[i].root, bti, tmp) {
+			btb_erase(btb, bti, i);
+			free(bti);
+		}
+	}
+}
+
+static void init_key(struct scoutfs_key *key, u8 zone, u8 type, u64 first, u64 second,
+		     u64 third, u8 fourth)
+{
+	key->_sk_first = cpu_to_le64(first);
+	key->_sk_second = cpu_to_le64(second);
+	key->_sk_third = cpu_to_le64(third);
+	key->_sk_fourth = cpu_to_le64(fourth);
+	key->sk_zone = cpu_to_le64(zone);
+	key->sk_type = cpu_to_le64(type);
+	memset(&key->__pad, 0, sizeof(key->__pad));
+}
+
+static u64 free_extent_order(u64 len)
+{
+	return (fls64(len | 1) - 1) / 3;
+}
+
+static int insert_free_items(struct btree_builder *btb, u64 start, u64 len)
+{
+	struct scoutfs_key keys[2];
+	struct btree_item *bti;
+	spr_err_t err;
+	u64 order;
+	u64 end;
+	int i;
+
+	end = start + len - 1;
+	order = U64_MAX - free_extent_order(len);
+
+	init_key(&keys[0], SCOUTFS_FREE_EXTENT_BLKNO_ZONE, 0, end, len, 0, 0);
+	init_key(&keys[1], SCOUTFS_FREE_EXTENT_ORDER_ZONE, 0, order, end, len, 0);
+
+	for (i = 0; i < array_size(keys); i++) {
+		err = bti_alloc(0, &bti);
+		if (err)
+			goto out;
+
+		bti->key = keys[i];
+
+		err = btb_insert(btb, bti, 0);
+		if (err) {
+			free(bti);
+			goto out;
+		}
+	}
+
+	btb->total_len += len;
+
+	err = 0;
+out:
+	return err;
+}
+
+static void set_alloc_root(struct scoutfs_alloc_root *root, struct btree_builder *btb)
+{
+	root->total_len = cpu_to_le64(btb->total_len);
+	root->flags = 0;
+	root->_pad = 0;
+	root->root = btb->btroot;
+}
+
+static spr_err_t map_start_key(struct scoutfs_key *start, struct scoutfs_key *key)
+{
+	if (key->sk_zone == SCOUTFS_FS_ZONE) {
+		init_key(start, SCOUTFS_FS_ZONE, 0,
+			 le64_to_cpu(key->_sk_first) & ~(u64)SCOUTFS_LOCK_INODE_GROUP_MASK,
+			 0, 0, 0);
+
+	} else if (key->sk_zone == SCOUTFS_XATTR_TOTL_ZONE) {
+		init_key(start, SCOUTFS_XATTR_TOTL_ZONE, 0, 0, 0, 0, 0);
+
+	} else if (key->sk_zone == SCOUTFS_INODE_INDEX_ZONE) {
+		init_key(start, SCOUTFS_INODE_INDEX_ZONE, 0, 0,
+			 le64_to_cpu(key->_sk_second) & ~(u64)SCOUTFS_LOCK_SEQ_GROUP_MASK,
+			 0, 0);
+
+	} else {
+		return EINVAL;
+	}
+
+	return 0;
+}
+
+static spr_err_t update_bloom(struct bloom_builder *bbld, struct scoutfs_key *key)
+{
+	struct scoutfs_bloom_block *bb = bbld->bloom;
+	unsigned int nrs[SCOUTFS_FOREST_BLOOM_NRS];
+	struct scoutfs_key start;
+	spr_err_t err;
+	int i;
+
+	err = map_start_key(&start, key);
+	if (err)
+		goto out;
+
+	calc_bloom_nrs(&start, nrs);
+
+	for (i = 0; i < SCOUTFS_FOREST_BLOOM_NRS; i++) {
+		if (!test_and_set_bit_le(nrs[i], bb->bits))
+			le64_add_cpu(&bb->total_set, 1);
+	}
+
+	err = 0;
+out:
+	return err;
+}
+
+static spr_err_t insert_fs_item(struct scoutfs_parallel_restore_writer *wri,
+				struct btree_item *bti)
+{
+	spr_err_t err;
+
+	if (bti->key.sk_zone == SCOUTFS_FS_ZONE && bti->key.sk_type == SCOUTFS_INODE_TYPE &&
+	    le64_to_cpu(bti->key.ski_ino) == SCOUTFS_ROOT_INO) {
+		err = btb_insert(&wri->root_btb, bti, 0);
+	} else {
+		err = btb_insert(&wri->fs_btb, bti, 0) ?:
+		      update_bloom(&wri->bloom_bbld, &bti->key);
+	}
+
+	return err;
+}
+
+static spr_err_t insert_entry_items(struct scoutfs_parallel_restore_writer *wri,
+				    struct scoutfs_parallel_restore_entry *entry)
+{
+	struct scoutfs_dirent *dent = NULL;
+	struct scoutfs_key keys[3];
+	struct btree_item *bti;
+	unsigned int bytes;
+	spr_err_t err = 0;
+	u64 dir_ino;
+	u64 hash;
+	u64 ino;
+	u64 pos;
+	int i;
+
+	bytes = offsetof(struct scoutfs_dirent, name[entry->name_len]);
+	dent = malloc(bytes);
+	if (!dent) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	dir_ino = entry->dir_ino;
+	ino = entry->ino;
+	hash = dirent_name_hash(entry->name, entry->name_len);
+	pos = entry->pos;
+
+	dent->ino = cpu_to_le64(ino);
+	dent->hash = cpu_to_le64(hash);
+	dent->pos = cpu_to_le64(pos);
+	dent->type = mode_to_type(entry->mode);
+	memset(&dent->__pad, 0, sizeof(dent->__pad));
+	memcpy(dent->name, entry->name, entry->name_len);
+
+	init_key(&keys[0], SCOUTFS_FS_ZONE, SCOUTFS_DIRENT_TYPE, dir_ino, hash, pos, 0);
+	init_key(&keys[1], SCOUTFS_FS_ZONE, SCOUTFS_READDIR_TYPE, dir_ino, pos, 0, 0);
+	init_key(&keys[2], SCOUTFS_FS_ZONE, SCOUTFS_LINK_BACKREF_TYPE, ino, dir_ino, pos, 0);
+
+	for (i = 0; i < array_size(keys); i++) {
+		err = bti_alloc(bytes, &bti);
+		if (err)
+			goto out;
+
+		bti->key = keys[i];
+		memcpy(bti->val, dent, bytes);
+
+		err = insert_fs_item(wri, bti);
+		if (err) {
+			free(bti);
+			goto out;
+		}
+	}
+
+	err = 0;
+out:
+	free(dent);
+	return err;
+}
+
+static spr_err_t insert_extent_item(struct scoutfs_parallel_restore_writer *wri, u64 ino, u64 len)
+{
+	struct scoutfs_data_extent_val *dv;
+	struct scoutfs_key key;
+	struct btree_item *bti;
+	spr_err_t err;
+
+	init_key(&key, SCOUTFS_FS_ZONE, SCOUTFS_DATA_EXTENT_TYPE, ino, 0 + len - 1, len, 0);
+
+	err = bti_alloc(sizeof(struct scoutfs_data_extent_val), &bti);
+	if (!err) {
+		dv = bti->val;
+		dv->blkno = 0;
+		dv->flags = SEF_OFFLINE;
+
+		err = insert_fs_item(wri, bti);
+		if (err)
+			free(bti);
+	}
+
+	return err;
+}
+
+/*
+ * We're trusting that the caller hasn't made up garbage xattrs.
+ * All we have to do is check for the scoutfs prefix and then
+ * identify the sequence of known tags.  There can be a lot more
+ * xattrs than files so this is a surprisingly hot path.
+ */
+#define HIDE_BE32 cpu_to_be32(0x68696465)
+#define SRCH_BE32 cpu_to_be32(0x73726368)
+#define TOTL_BE32 cpu_to_be32(0x746f746c)
+#define TAG_LEN 5
+#define XTAG_SRCH (1 << 1)
+#define XTAG_TOTL (1 << 2)
+static int get_xattr_tags(char *name, int name_len)
+{
+	static const char prefix[] = "scoutfs.";
+	static const size_t prefix_len = array_size(prefix) - 1;
+	__be32 betag;
+	int xtags = 0;
+
+	if (name_len < prefix_len || strncmp(name, prefix, prefix_len))
+		return 0;
+
+	name += prefix_len;
+	name_len -= prefix_len;
+
+	while (name_len >= TAG_LEN && name[TAG_LEN - 1] == '.') {
+		memcpy(&betag, name, sizeof(betag));
+
+		dprintf("tag 0x%08x\n", be32_to_cpu(betag));
+
+		if (betag == HIDE_BE32)
+			;
+		else if (betag == SRCH_BE32)
+			xtags |= XTAG_SRCH;
+		else if (betag == TOTL_BE32)
+			xtags |= XTAG_TOTL;
+		else
+			break;
+
+		name += TAG_LEN;
+		name_len -= TAG_LEN;
+	}
+
+	dprintf("xat name %.*s tags 0x%x\n", name_len, name, xtags);
+
+	return xtags;
+}
+
+static spr_err_t insert_xattr_items(struct scoutfs_parallel_restore_writer *wri,
+				    struct scoutfs_parallel_restore_xattr *xattr, u32 hash)
+{
+	struct scoutfs_xattr xat;
+	struct iovec value[3] = {
+		{ &xat, sizeof(xat) },
+		{ xattr->name, xattr->name_len, },
+		{ xattr->value, xattr->value_len, },
+	};
+	struct iovec *iov = value;
+	struct scoutfs_key key;
+	struct btree_item *bti;
+	unsigned int total;
+	unsigned int bytes;
+	unsigned int piece;
+	spr_err_t err;
+	char *buf;
+
+	init_key(&key, SCOUTFS_FS_ZONE, SCOUTFS_XATTR_TYPE, xattr->ino, hash, xattr->pos, 0);
+	total = value[0].iov_len + value[1].iov_len + value[2].iov_len;
+
+	xat.val_len = cpu_to_le16(xattr->value_len);
+	xat.name_len = xattr->name_len;
+	memset(xat.__pad, 0, sizeof(xat.__pad));
+
+	while (total > 0) {
+		bytes = min(total, SCOUTFS_XATTR_MAX_PART_SIZE);
+
+		err = bti_alloc(bytes, &bti);
+		if (err)
+			goto out;
+
+		bti->key = key;
+		buf = bti->val;
+
+		while (bytes) {
+			piece = min(bytes, iov->iov_len);
+			memcpy(buf, iov->iov_base, piece);
+			buf += piece;
+			bytes -= piece;
+			total -= piece;
+			iov->iov_base += piece;
+			iov->iov_len -= piece;
+			if (iov->iov_len == 0)
+				iov++; /* falls off array when done */
+		}
+
+		err = insert_fs_item(wri, bti);
+		if (err) {
+			free(bti);
+			goto out;
+		}
+
+		key._sk_fourth++;
+	}
+
+	err = 0;
+out:
+	return err;
+}
+
+static spr_err_t insert_symlink_items(struct scoutfs_parallel_restore_writer *wri,
+				      u64 ino, char *target, int target_len)
+{
+	struct scoutfs_key key;
+	struct btree_item *bti;
+	spr_err_t err;
+	int bytes;
+	int off = 0;
+
+	init_key(&key, SCOUTFS_FS_ZONE, SCOUTFS_SYMLINK_TYPE, ino, 0, 0, 0);
+
+	while (off < target_len) {
+		bytes = min(target_len - off, SCOUTFS_MAX_VAL_SIZE);
+
+		err = bti_alloc(bytes, &bti);
+		if (err)
+			goto out;
+
+		bti->key = key;
+		memcpy(bti->val, target + off, bytes);
+
+		off += bytes;
+		key._sk_second++;
+	}
+
+	err = 0;
+out:
+	return err;
+}
+
+/* forbid the leading + that strtoull allows */
+static spr_err_t totl_strtoull(char *s, int len, unsigned long long *res)
+{
+	char str[SCOUTFS_XATTR_MAX_TOTL_U64 + 1];
+
+	if (len <= 0 || len >= array_size(str) || s[0] == '+')
+		return EINVAL;
+
+	memcpy(str, s, len);
+	str[len] = '\0';
+
+	errno = 0;
+	*res = strtoull(str, NULL, 0);
+	return errno;
+}
+
+/*
+ * .totl. xattrs turn into items with the key based on dotted u64s at the end of the
+ * name and a value in the .. value.
+ */
+static spr_err_t insert_totl_item(struct scoutfs_parallel_restore_writer *wri,
+				  struct scoutfs_parallel_restore_xattr *xattr)
+{
+	static const char prefix[] = "scoutfs.totl.";
+	static const int prefix_len = sizeof(prefix) - 1;
+	struct scoutfs_xattr_totl_val *found_tval;
+	struct scoutfs_xattr_totl_val *tval;
+	struct btree_item *found;
+	struct btree_item *bti;
+	unsigned long long longs[3];
+	unsigned long long v;
+	spr_err_t err;
+	int nr = 0;
+	int prev;
+	int i;
+
+	prev = xattr->name_len;
+	for (i = xattr->name_len - 1; i > prefix_len; i--) {
+		if (xattr->name[i] == '.') {
+			err = totl_strtoull(&xattr->name[i + 1], prev - (i + 1), &longs[nr]);
+			if (err)
+				goto out;
+			if (++nr == array_size(longs))
+				break;
+			prev = i;
+		}
+	}
+	if (nr != array_size(longs)) {
+		err = EINVAL;
+		goto out;
+	}
+
+	err = totl_strtoull(xattr->value, xattr->value_len, &v);
+	if (err)
+		goto out;
+
+	if (v == 0) {
+		err = 0;
+		goto out;
+	}
+
+	err = bti_alloc(sizeof(struct scoutfs_xattr_totl_val), &bti);
+	if (err)
+		goto out;
+
+	init_key(&bti->key, SCOUTFS_XATTR_TOTL_ZONE, 0, longs[2], longs[1], longs[0], 0);
+	tval = bti->val;
+	tval->total = cpu_to_le64(v);
+	tval->count = cpu_to_le64(1);
+
+	found = bti_walk(&wri->fs_btb.items[0].root, &bti->key, NULL);
+	if (found) {
+		found_tval = found->val;
+		le64_add_cpu(&found_tval->total, le64_to_cpu(tval->total));
+		le64_add_cpu(&found_tval->count, le64_to_cpu(tval->count));
+		if (found_tval->total == 0)
+			btb_erase(&wri->fs_btb, found, 0);
+		free(bti);
+	} else {
+		err = insert_fs_item(wri, bti);
+		if (err) {
+			free(bti);
+			goto out;
+		}
+	}
+
+	err = 0;
+out:
+	return err;
+}
+
+static spr_err_t insert_inode_index_item(struct scoutfs_parallel_restore_writer *wri,
+					 u8 type, u64 major, u64 ino)
+{
+	struct btree_item *bti;
+	spr_err_t err;
+
+	err = bti_alloc(0, &bti);
+	if (!err) {
+		init_key(&bti->key, SCOUTFS_INODE_INDEX_ZONE, type, 0, major, ino, 0);
+		err = insert_fs_item(wri, bti);
+		if (err)
+			free(bti);
+	}
+
+	return err;
+}
+
+static spr_err_t insert_inode_items(struct scoutfs_parallel_restore_writer *wri,
+				    struct scoutfs_parallel_restore_inode *inode)
+{
+	struct scoutfs_inode *si;
+	struct btree_item *bti;
+	spr_err_t err;
+
+	err = bti_alloc(sizeof(struct scoutfs_inode), &bti);
+	if (err)
+		goto out;
+
+	init_key(&bti->key, SCOUTFS_FS_ZONE, SCOUTFS_INODE_TYPE, inode->ino, 0, 0, 0);
+
+	si = bti->val;
+
+	si->size = 0;
+	si->meta_seq = cpu_to_le64(inode->ino);
+	si->data_seq = 0;
+	si->data_version = 0;
+	si->online_blocks = 0;
+	si->offline_blocks = 0;
+	si->next_readdir_pos = 0;
+	si->next_xattr_id = cpu_to_le64(inode->nr_xattrs + 1);
+	si->version = cpu_to_le64(1);
+	si->nlink = cpu_to_le32(1);
+	si->uid = cpu_to_le32(inode->uid);
+	si->gid = cpu_to_le32(inode->gid);
+	si->mode = cpu_to_le32(inode->mode);
+	si->rdev = cpu_to_le32(inode->rdev);
+	si->flags = 0;
+	si->version = cpu_to_le64(1);
+	si->atime.sec = cpu_to_le64(inode->atime.tv_sec);
+	si->atime.nsec = cpu_to_le32(inode->atime.tv_nsec);
+	si->ctime.sec = cpu_to_le64(inode->ctime.tv_sec);
+	si->ctime.nsec = cpu_to_le32(inode->ctime.tv_nsec);
+	si->mtime.sec = cpu_to_le64(inode->mtime.tv_sec);
+	si->mtime.nsec = cpu_to_le32(inode->mtime.tv_nsec);
+	si->crtime.sec = cpu_to_le64(inode->crtime.tv_sec);
+	si->crtime.nsec = cpu_to_le32(inode->crtime.tv_nsec);
+
+	err = insert_inode_index_item(wri, SCOUTFS_INODE_INDEX_META_SEQ_TYPE,
+				      le64_to_cpu(si->meta_seq), inode->ino);
+	if (err)
+		goto out;
+
+	if (S_ISREG(inode->mode)) {
+		si->size = cpu_to_le64(inode->size);
+		si->data_version = le64_to_cpu(inode->data_version);
+		si->data_seq = cpu_to_le64(inode->ino);
+
+		err = insert_inode_index_item(wri, SCOUTFS_INODE_INDEX_DATA_SEQ_TYPE,
+					      le64_to_cpu(si->data_seq), inode->ino);
+		if (err)
+			goto out;
+
+		if (inode->offline) {
+			si->offline_blocks = cpu_to_le64(DIV_ROUND_UP(inode->size,
+								      SCOUTFS_BLOCK_SM_SIZE));
+			err = insert_extent_item(wri, inode->ino, si->offline_blocks);
+			if (err)
+				goto out;
+		}
+
+	} else if (S_ISDIR(inode->mode)) {
+		si->size = cpu_to_le64(inode->total_entry_name_bytes);
+		si->next_readdir_pos = cpu_to_le64(SCOUTFS_DIRENT_FIRST_POS + inode->nr_subdirs);
+		si->nlink = cpu_to_le32(2 + inode->nr_subdirs);
+
+	} else if (S_ISLNK(inode->mode)) {
+		si->size = cpu_to_le64(inode->target_len);
+
+		err = insert_symlink_items(wri, inode->ino, inode->target, inode->target_len);
+		if (err)
+			goto out;
+	}
+
+	err = insert_fs_item(wri, bti);
+out:
+	return err;
+}
+
+static spr_err_t insert_log_trees_item(struct scoutfs_parallel_restore_writer *wri,
+				       struct scoutfs_parallel_restore_progress *prog)
+{
+	struct scoutfs_log_trees *lt;
+	struct btree_item *bti;
+	spr_err_t err;
+
+	err = bti_alloc(sizeof(struct scoutfs_log_trees), &bti);
+	if (err)
+		goto out;
+
+	lt = bti->val;
+	memset(lt, 0, sizeof(struct scoutfs_log_trees));
+	lt->item_root = prog->fs_items;
+	lt->bloom_ref = prog->bloom_ref;
+	/* lt srch_file is blank once finalized, moved to srch_root items */
+	lt->inode_count_delta = prog->inode_count;
+	lt->get_trans_seq = cpu_to_le64(1);
+	lt->commit_trans_seq = cpu_to_le64(1);
+	lt->max_item_seq = cpu_to_le64(1);
+	lt->finalize_seq = cpu_to_le64(1);
+	lt->rid = cpu_to_le64(prog->max_ino);
+	lt->nr = cpu_to_le64(1);
+	lt->flags = cpu_to_le64(SCOUTFS_LOG_TREES_FINALIZED);
+
+	init_key(&bti->key, SCOUTFS_LOG_TREES_ZONE, 0,
+		 le64_to_cpu(lt->rid), le64_to_cpu(lt->nr), 0, 0);
+
+	err = btb_insert(&wri->log_btb, bti, 0);
+out:
+	return err;
+}
+
+static spr_err_t insert_srch_item(struct scoutfs_parallel_restore_writer *wri,
+				  struct scoutfs_srch_file *sfl)
+{
+	struct btree_item *bti;
+	spr_err_t err;
+
+	err = bti_alloc(sizeof(struct scoutfs_srch_file), &bti);
+	if (!err) {
+		init_key(&bti->key, SCOUTFS_SRCH_ZONE, SCOUTFS_SRCH_BLOCKS_TYPE,
+			 0, le64_to_cpu(sfl->blocks), le64_to_cpu(sfl->ref.blkno), 0);
+		memcpy(bti->val, sfl, sizeof(struct scoutfs_srch_file));
+		err = btb_insert(&wri->srch_btb, bti, 0);
+	}
+
+	return err;
+}
+
+#define UNLINKED_AVL_HEIGHT 255
+
+static void link_avl_nodes(struct scoutfs_btree_block *bt, __le16 *parent, __le16 parent_off,
+			   u8 height, int first, int last)
+{
+	int ind = (first + last) / 2;
+	struct scoutfs_avl_node *node = &bt->items[ind].node;
+	u64 off = cpu_to_le16((long)node - (long)&bt->item_root);
+
+	dprintf("first %d ind %d last %d height %u\n", first, ind, last, height);
+
+	if (ind < first || ind > last || node->height != UNLINKED_AVL_HEIGHT)
+		return;
+
+	*parent = cpu_to_le16(off);
+	node->parent = parent_off;
+	node->height = height;
+	node->left = 0;
+	node->right = 0;
+	memset(node->__pad, 0, sizeof(node->__pad));
+
+	if (height > 1) {
+		link_avl_nodes(bt, &node->left, off, height - 1, first, ind - 1);
+		link_avl_nodes(bt, &node->right, off, height - 1, ind + 1, last);
+	}
+}
+
+#define DEFINE_BUILDER_CONTAINER(type, name, ptr) \
+	type *name = container_of(ptr, type, bld)
+
+static bool btree_empty(struct block_builder *bld)
+{
+	DEFINE_BUILDER_CONTAINER(struct btree_builder, btb, bld);
+
+	return btb->total_items == 0;
+}
+
+static void btree_reset(struct block_builder *bld)
+{
+	DEFINE_BUILDER_CONTAINER(struct btree_builder, btb, bld);
+
+	btb->total_items = 0;
+	btb->total_len = 0;
+	memset(&btb->btroot, 0, sizeof(btb->btroot));
+}
+
+/*
+ * Incrementally build btrees.  By the time we're called the builder has
+ * all the sorted leaf items in an rbtree at their level.  We streaem
+ * them into blocks and store parent items at the next highest level.
+ * Once we're out of leaf items we stream the parent items into blocks
+ * and store their parent items at the next highest level.  Eventually
+ * we drain all the items and are left with the root's reference to the
+ * first block in the tree.
+ */
+static spr_err_t build_btree_block(struct scoutfs_parallel_restore_writer *wri,
+				   struct block_builder *bld, void *buf, u64 blkno)
+{
+	DEFINE_BUILDER_CONTAINER(struct btree_builder, btb, bld);
+	struct scoutfs_block_header *hdr;
+	struct scoutfs_btree_item *item;
+	struct scoutfs_btree_block *bt;
+	struct scoutfs_block_ref *ref;
+	struct btree_item *bti;
+	struct btree_item *tmp;
+	unsigned long val_align;
+	unsigned long bytes;
+	unsigned long nr;
+	void *val_buf;
+	spr_err_t err;
+	u8 height;
+	int level;
+	int i;
+
+	/* find next highest level to build items from */
+	for (i = 0; i < SCOUTFS_BTREE_MAX_HEIGHT; i++) {
+		if (btb->items[i].nr == 0)
+			continue;
+
+		level = i;
+		break;
+	}
+
+	/* shouldn't be possible */
+	if (i >= SCOUTFS_BTREE_MAX_HEIGHT) {
+		err = ENOBUFS;
+		goto out;
+	}
+
+	dprintf("building btree blkno %llu level %u nr %lu tot %llu \n",
+		blkno, level, btb->items[level].nr, btb->total_items);
+
+	/*
+	 * XXX Be more careful about item filling.. can parents be entirely
+	 * full?  Should we let the last nodes on the right be under the
+	 * min?  We can see that there are < (nr + min) left and emit
+	 * half the remaining in each.
+	 */
+
+	/* initialize the non-item parts of the block */
+	bt = buf;
+	memset(bt, 0, sizeof(struct scoutfs_btree_block));
+	hdr = &bt->hdr;
+	hdr->magic = cpu_to_le32(SCOUTFS_BLOCK_MAGIC_BTREE);
+	hdr->fsid = wri->fsid;
+	hdr->blkno = cpu_to_le64(blkno);
+	hdr->seq = cpu_to_le64(1);
+	bt->level = level;
+	btree_init_block(bt, level);
+	if (level == 0)
+		memset((char *)bt + SCOUTFS_BLOCK_LG_SIZE - SCOUTFS_BTREE_LEAF_ITEM_HASH_BYTES, 0,
+		       SCOUTFS_BTREE_LEAF_ITEM_HASH_BYTES);
+
+	/* find the items that fit in the leaf */
+	item = &bt->items[0];
+	nr = 0;
+	val_buf = (void *)item + le16_to_cpu(bt->mid_free_len);
+
+	for_each_bti_safe(&btb->items[level].root, bti, tmp) {
+		val_align = round_up(bti->val_len, SCOUTFS_BTREE_VALUE_ALIGN);
+		bytes = sizeof(struct scoutfs_btree_item) + val_align;
+
+		if (le16_to_cpu(bt->mid_free_len) < bytes)
+			break;
+
+		item->node.height = UNLINKED_AVL_HEIGHT;
+		item->key = bti->key;
+		item->seq = cpu_to_le64(1);
+		item->val_len = cpu_to_le16(bti->val_len);
+		item->flags = 0;
+		memset(item->node.__pad, 0, sizeof(item->node.__pad));
+
+		if (bti->val_len) {
+			val_buf -= val_align;
+			item->val_off = cpu_to_le16((long)val_buf - (long)bt);
+			memcpy(val_buf, bti->val, bti->val_len);
+		} else {
+			item->val_off = 0;
+		}
+
+		le16_add_cpu(&bt->nr_items, 1);
+		le16_add_cpu(&bt->total_item_bytes, bytes);
+		le16_add_cpu(&bt->mid_free_len, -bytes);
+		if (level == 0)
+			leaf_item_hash_insert(bt, &item->key,
+					      cpu_to_le16((void *)item - (void *)bt));
+
+		item++;
+		nr++;
+
+		btb_erase(btb, bti, level);
+		free(bti);
+	}
+
+	/* zero the middle of the block without items */
+	if (bt->mid_free_len)
+		memset(&bt->items[nr], 0, le16_to_cpu(bt->mid_free_len));
+
+	height = (int)ceil(log2(nr)) + 2; /* leaves are height 1 */
+	link_avl_nodes(bt, &bt->item_root.node, 0, height - 1, 0, nr - 1);
+
+	/* finish block */
+	hdr->crc = cpu_to_le32(crc_block(hdr, SCOUTFS_BLOCK_LG_SIZE));
+
+	if (btb->total_items == 0) {
+		/* root refs hightest/last block we build */
+		btb->btroot.ref.blkno = hdr->blkno;
+		btb->btroot.ref.seq = hdr->seq;
+		btb->btroot.height = level +1;
+	} else {
+		/* parent ref items will be built into parent blocks */
+		/* we'll always need a parent ref for the block we're building */
+		err = bti_alloc(sizeof(struct scoutfs_block_ref), &bti);
+		if (err)
+			goto out;
+
+		/* refs to right spine blocks has all ones key */
+		if (btb->items[level].nr == 0)
+			scoutfs_key_set_ones(&bti->key);
+		else
+			bti->key = bt->items[nr - 1].key;
+		ref = bti->val;
+		ref->blkno = hdr->blkno;
+		ref->seq = hdr->seq;
+		btb_insert(btb, bti, level + 1);
+	}
+
+	err = 0;
+out:
+	return err;
+}
+
+static void btb_init(struct btree_builder *btb)
+{
+	int i;
+
+	init_builder(&btb->bld, btree_empty, btree_reset, build_btree_block);
+
+	for (i = 0; i < array_size(btb->items); i++)
+		btb->items[i].root = RB_ROOT;
+}
+
+/*
+ * This is how we get around the recursion of allocating blocks to write blocks that
+ * store the allocators.  After we've written all other metadata blocks we know precisely
+ * how many allocation blocks we'll need.  We modify the writer to only have that many
+ * free blocks remaining and put the rest in the alloc block builders.
+ */
+static spr_err_t prepare_alloc_builders(struct scoutfs_parallel_restore_writer *wri,
+					struct block_builder *bld)
+{
+#define ALLOC_BLOCKS 5 /* 2 meta list, 2 meta btree, 1 data btree */
+	struct extent_head *eh_tmp;
+	struct extent_head *eh;
+	spr_err_t err;
+	u64 start;
+	u64 skip;
+	u64 len;
+	int ind;
+
+	dprintf("starting prepare with start %llu len %llu\n", wri->meta_start, wri->meta_len);
+
+	skip = ALLOC_BLOCKS + (SCOUTFS_ALLOC_LIST_MAX_BLOCKS * 2);
+	if (wri->meta_len <= skip)
+		return ENOSPC;
+
+	/* store remainder of meta alloc as a free extent */
+	start = wri->meta_start + skip;
+	len = wri->meta_len - skip;
+	err = insert_free_items(&wri->meta_btb[0], start, len);
+	if (err)
+		goto out;
+	wri->meta_len -= len;
+
+	/* the rest of the meta extents are items in the two meta trees */
+	ind = 1;
+	list_for_each_entry_safe(eh, eh_tmp, &wri->meta_extents, head) {
+		err = insert_free_items(&wri->meta_btb[ind], eh->start, eh->len);
+		if (err)
+			goto out;
+		list_del_init(&eh->head);
+		free(eh);
+		ind ^= 1;
+	}
+
+	/* fill the two server avail alloc list blocks */
+	wri->meta_alb[0].start = wri->meta_start + ALLOC_BLOCKS;
+	wri->meta_alb[0].len = SCOUTFS_ALLOC_LIST_MAX_BLOCKS;
+	wri->meta_alb[1].start = wri->meta_alb[0].start + wri->meta_alb[0].len;
+	wri->meta_alb[1].len = wri->meta_alb[0].len;
+
+	/* writer left with only meta allocation for remaining alloc blocks */
+	wri->meta_len = ALLOC_BLOCKS;
+
+	err = 0;
+out:
+	return err;
+}
+
+static bool alloc_list_empty(struct block_builder *bld)
+{
+	DEFINE_BUILDER_CONTAINER(struct alloc_list_builder, alb, bld);
+
+	return alb->len == 0;
+}
+
+static spr_err_t build_alloc_list_block(struct scoutfs_parallel_restore_writer *wri,
+					struct block_builder *bld, void *buf, u64 blkno)
+{
+	DEFINE_BUILDER_CONTAINER(struct alloc_list_builder, alb, bld);
+	struct scoutfs_alloc_list_block *lblk;
+	struct scoutfs_block_header *hdr;
+	int i;
+
+	if (alb->len > SCOUTFS_ALLOC_LIST_MAX_BLOCKS)
+		return EOVERFLOW;
+
+	lblk = buf;
+	memset(&lblk->next, 0, sizeof(lblk->next));
+	lblk->start = 0;
+	lblk->nr = cpu_to_le64(alb->len);
+
+	for (i = 0; i < alb->len; i++)
+		lblk->blknos[i] = cpu_to_le64(alb->start + i);
+
+	hdr = &lblk->hdr;
+	hdr->magic = cpu_to_le32(SCOUTFS_BLOCK_MAGIC_ALLOC_LIST);
+	hdr->fsid = wri->fsid;
+	hdr->blkno = cpu_to_le64(blkno);
+	hdr->seq = cpu_to_le64(1);
+	hdr->crc = cpu_to_le32(crc_block(hdr, SCOUTFS_BLOCK_LG_SIZE));
+
+	alb->lhead.ref.blkno = hdr->blkno;
+	alb->lhead.ref.seq = hdr->seq;
+	alb->lhead.first_nr = cpu_to_le32(alb->len);
+	alb->lhead.total_nr = cpu_to_le64(alb->len);
+
+	alb->start = 0;
+	alb->len = 0;
+
+	return 0;
+}
+
+static void init_alb(struct alloc_list_builder *alb)
+{
+	init_builder(&alb->bld, alloc_list_empty, NULL, build_alloc_list_block);
+}
+
+static struct srch_node *node_srn(struct rb_node *node)
+{
+	return node ? container_of(node, struct srch_node, node) : NULL;
+}
+
+static struct srch_node *srn_first(struct rb_root *root)
+{
+	return node_srn(rb_first(root));
+}
+
+static struct srch_node *srn_next(struct srch_node *srn)
+{
+	return srn ? node_srn(rb_next(&srn->node)) : NULL;
+}
+
+static spr_err_t insert_srch_entry(struct srch_builder *sbld, u64 hash, u64 ino, u64 id)
+{
+	struct rb_root *root = &sbld->entries;
+	struct rb_node **node = &root->rb_node;
+	struct rb_node *parent = NULL;
+	struct srch_node *ins;
+	struct srch_node *srn;
+	int cmp;
+
+	ins = malloc(sizeof(struct srch_node));
+	if (!ins)
+		return ENOMEM;
+
+	ins->hash = hash;
+	ins->ino = ino;
+	ins->id = id;
+
+	while (*node) {
+		parent = *node;
+		srn = node_srn(*node);
+
+		cmp = scoutfs_cmp(ins->hash, srn->hash) ?:
+		      scoutfs_cmp(ins->ino, srn->ino) ?:
+		      scoutfs_cmp(ins->id, srn->id);
+		if (cmp < 0)
+			node = &(*node)->rb_left;
+		else if (cmp > 0)
+			node = &(*node)->rb_right;
+		else
+			return EEXIST;
+	}
+
+	rb_link_node(&ins->node, parent, node);
+	rb_insert_color(&ins->node, root);
+
+	return 0;
+}
+
+static bool srch_empty(struct block_builder *bld)
+{
+	DEFINE_BUILDER_CONTAINER(struct srch_builder, sbld, bld);
+
+	return RB_EMPTY_ROOT(&sbld->entries) && sbld->total_parent_refs == 0;
+}
+
+static void srch_reset(struct block_builder *bld)
+{
+	DEFINE_BUILDER_CONTAINER(struct srch_builder, sbld, bld);
+
+	memset(&sbld->sfl, 0, sizeof(sbld->sfl));
+}
+
+#define for_each_sbld_parent(sbld, i) \
+	for (i = 1; i < array_size(sbld->parents); i++)
+
+static spr_err_t build_srch_block(struct scoutfs_parallel_restore_writer *wri,
+				   struct block_builder *bld, void *buf, u64 blkno)
+{
+	DEFINE_BUILDER_CONTAINER(struct srch_builder, sbld, bld);
+	struct scoutfs_block_header *hdr;
+	struct scoutfs_srch_parent *par;
+	struct scoutfs_srch_block *srb;
+	struct scoutfs_srch_entry sre;
+	struct scoutfs_block_ref *ref;
+	struct srch_node *srn_tmp;
+	struct srch_node *srn;
+	unsigned int nr;
+	spr_err_t err;
+	u32 magic;
+	int level;
+	int tail;
+	int ret;
+
+	dprintf("building srch blkno %llu empty_entries %u tot refs %llu parent nrs: ",
+		blkno, RB_EMPTY_ROOT(&sbld->entries), sbld->total_parent_refs);
+	for_each_sbld_parent(sbld, level)
+		dprintf("%u:%lu ", level, sbld->parents[level].nr);
+	dprintf("\n");
+
+	/* build parents with refs that are full or when we're out of entries */
+	for_each_sbld_parent(sbld, level) {
+
+		nr = sbld->parents[level].nr;
+		if (nr == 0 || (nr < SCOUTFS_SRCH_PARENT_REFS && !RB_EMPTY_ROOT(&sbld->entries)))
+			continue;
+
+		/* copy parent refs */
+		par = buf;
+		memcpy(par->refs, sbld->parents[level].refs, nr * sizeof(par->refs[0]));
+		sbld->total_parent_refs -= nr;
+		sbld->parents[level].nr = 0;
+
+		/* zero the tail of the block */
+		tail = SCOUTFS_BLOCK_LG_SIZE - offsetof(struct scoutfs_srch_parent, refs[nr]);
+		if (tail > 0)
+			memset(buf + SCOUTFS_BLOCK_LG_SIZE - tail, 0, tail);
+
+		magic = SCOUTFS_BLOCK_MAGIC_SRCH_PARENT;
+		hdr = &par->hdr;
+		goto finish_hdr;
+	}
+
+	/* no built parent, must have entries to build */
+	level = 0;
+	if (RB_EMPTY_ROOT(&sbld->entries)) {
+		err = EINVAL;
+		goto out;
+	}
+
+	srn = srn_first(&sbld->entries);
+	sre.hash = cpu_to_le64(srn->hash);
+	sre.ino = cpu_to_le64(srn->ino);
+	sre.id = cpu_to_le64(srn->id);
+
+	srb = buf;
+	srb->entry_nr = 0;
+	srb->entry_bytes = 0;
+	srb->first = sre;
+	memset(&srb->tail, 0, sizeof(srb->tail));
+
+	if (sbld->sfl.blocks == 0)
+		sbld->sfl.first = sre;
+
+	do {
+		if (le32_to_cpu(srb->entry_bytes) > SCOUTFS_SRCH_BLOCK_SAFE_BYTES)
+			break;
+
+		ret = srch_encode_entry(srb->entries + le32_to_cpu(srb->entry_bytes),
+					&sre, &srb->tail);
+
+		dprintf("%llu.%llu.%llu ret %d\n", srn->hash, srn->ino, srn->id, ret);
+
+		le32_add_cpu(&srb->entry_bytes, ret);
+		le32_add_cpu(&srb->entry_nr, 1);
+		srb->tail = sre;
+
+		srn_tmp = srn_next(srn);
+		rb_erase(&srn->node, &sbld->entries);
+		free(srn);
+
+		if ((srn = srn_tmp)) {
+			sre.hash = cpu_to_le64(srn->hash);
+			sre.ino = cpu_to_le64(srn->ino);
+			sre.id = cpu_to_le64(srn->id);
+		}
+	} while (srn);
+
+	srb->last = srb->tail;
+	sbld->sfl.last = srb->tail;
+
+	le64_add_cpu(&sbld->sfl.blocks, 1);
+	le64_add_cpu(&sbld->sfl.entries, le32_to_cpu(srb->entry_nr));
+
+	magic = SCOUTFS_BLOCK_MAGIC_SRCH_BLOCK;
+	hdr = &srb->hdr;
+
+finish_hdr:
+	hdr->magic = cpu_to_le32(magic);
+	hdr->fsid = wri->fsid;
+	hdr->blkno = cpu_to_le64(blkno);
+	hdr->seq = cpu_to_le64(1);
+	hdr->crc = cpu_to_le32(crc_block(hdr, SCOUTFS_BLOCK_LG_SIZE));
+
+	if (srch_empty(&sbld->bld)) {
+		/* the last block is referenced by the root */
+		sbld->sfl.ref.blkno = hdr->blkno;
+		sbld->sfl.ref.seq = hdr->seq;
+		sbld->sfl.height = level + 1;
+		memset(sbld->sfl.__pad, 0, sizeof(sbld->sfl.__pad));
+	} else {
+		/* store the parent ref to our block */
+		nr = sbld->parents[level + 1].nr++;
+		ref = &sbld->parents[level + 1].refs[nr];
+		ref->blkno = hdr->blkno;
+		ref->seq = hdr->seq;
+		sbld->total_parent_refs++;
+	}
+
+	err = 0;
+out:
+	return err;
+}
+
+static spr_err_t sbld_create(struct srch_builder *sbld)
+{
+	spr_err_t err = 0;
+	int i;
+
+	init_builder(&sbld->bld, srch_empty, srch_reset, build_srch_block);
+
+	for_each_sbld_parent(sbld, i) {
+		sbld->parents[i].refs = malloc(SCOUTFS_SRCH_PARENT_REFS *
+					       sizeof(struct scoutfs_block_ref));
+		if (!sbld->parents[i].refs) {
+			while (--i >= 1) {
+				free(sbld->parents[i].refs);
+				sbld->parents[i].refs = NULL;
+			}
+			err = ENOMEM;
+			break;
+		}
+	}
+
+	return err;
+}
+
+static void sbld_destroy(struct srch_builder *sbld)
+{
+	int i;
+
+	for_each_sbld_parent(sbld, i) {
+		free(sbld->parents[i].refs);
+		sbld->parents[i].refs = NULL;
+	}
+}
+
+/*
+ * We've written the bloom block if we've filled out its header.
+ */
+static bool bloom_empty(struct block_builder *bld)
+{
+	DEFINE_BUILDER_CONTAINER(struct bloom_builder, bbld, bld);
+
+	return bbld->bloom->hdr.seq != 0;
+}
+
+static void bloom_reset(struct block_builder *bld)
+{
+	DEFINE_BUILDER_CONTAINER(struct bloom_builder, bbld, bld);
+
+	memset(bbld->bloom, 0, SCOUTFS_BLOCK_LG_SIZE);
+}
+
+static spr_err_t build_bloom_block(struct scoutfs_parallel_restore_writer *wri,
+				   struct block_builder *bld, void *buf, u64 blkno)
+{
+	DEFINE_BUILDER_CONTAINER(struct bloom_builder, bbld, bld);
+	struct scoutfs_block_header *hdr;
+
+	hdr = &bbld->bloom->hdr;
+	hdr->magic = cpu_to_le32(SCOUTFS_BLOCK_MAGIC_BLOOM);
+	hdr->fsid = wri->fsid;
+	hdr->blkno = cpu_to_le64(blkno);
+	hdr->seq = cpu_to_le64(1);
+	hdr->crc = cpu_to_le32(crc_block(hdr, SCOUTFS_BLOCK_LG_SIZE));
+
+	memcpy(buf, bbld->bloom, SCOUTFS_BLOCK_LG_SIZE);
+
+	return 0;
+}
+
+static spr_err_t bbld_create(struct bloom_builder *bbld)
+{
+	init_builder(&bbld->bld, bloom_empty, bloom_reset, build_bloom_block);
+
+	bbld->bloom = malloc(SCOUTFS_BLOCK_LG_SIZE);
+	if (!bbld->bloom)
+		return ENOMEM;
+
+	memset(&bbld->bloom->hdr, 0, sizeof(bbld->bloom->hdr));
+
+	return 0;
+}
+
+static void bbld_destroy(struct bloom_builder *bbld)
+{
+	free(bbld->bloom);
+}
+
+static bool wri_has_super(struct scoutfs_parallel_restore_writer *wri)
+{
+	return wri->super.hdr.blkno != 0;
+}
+
+static void reset_builders(struct scoutfs_parallel_restore_writer *wri)
+{
+	/* define block build order, different than struct layout order */
+	struct block_builder *builders[] = {
+		/* fs items written in parallel by writers */
+		&wri->fs_btb.bld,
+		&wri->bloom_bbld.bld,
+		&wri->srch_sbld.bld,
+
+		/* global items written finally by global super writer */
+		&wri->root_btb.bld,
+		&wri->srch_btb.bld,
+		/* log .post() prepares final allocators */
+		&wri->log_btb.bld,
+		&wri->meta_alb[0].bld,
+		&wri->meta_alb[1].bld,
+		&wri->meta_btb[0].bld,
+		&wri->meta_btb[1].bld,
+		&wri->data_btb.bld,
+	};
+	struct block_builder *bld;
+	int i;
+
+	for (i = 0; i < array_size(builders); i++) {
+		bld = builders[i];
+
+		if (bld->reset)
+			bld->reset(bld);
+
+		if (!list_empty(&bld->head))
+			list_del_init(&bld->head);
+		list_add_tail(&bld->head, &wri->builders);
+	}
+}
+
+spr_err_t scoutfs_parallel_restore_create_writer(struct scoutfs_parallel_restore_writer **wrip)
+{
+	struct scoutfs_parallel_restore_writer *wri;
+	spr_err_t err;
+
+	wri = calloc(1, sizeof(struct scoutfs_parallel_restore_writer));
+	if (!wri) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	INIT_LIST_HEAD(&wri->meta_extents);
+	INIT_LIST_HEAD(&wri->builders);
+	btb_init(&wri->root_btb);
+	btb_init(&wri->fs_btb);
+	btb_init(&wri->srch_btb);
+	btb_init(&wri->log_btb);
+	btb_init(&wri->meta_btb[0]);
+	btb_init(&wri->meta_btb[1]);
+	btb_init(&wri->data_btb);
+	init_alb(&wri->meta_alb[0]);
+	init_alb(&wri->meta_alb[1]);
+
+	err = sbld_create(&wri->srch_sbld) ?:
+	      bbld_create(&wri->bloom_bbld);
+	if (err)
+		goto out;
+
+	reset_builders(wri);
+	err = 0;
+out:
+	if (err) {
+		if (wri) {
+			sbld_destroy(&wri->srch_sbld);
+			bbld_destroy(&wri->bloom_bbld);
+			free(wri);
+		}
+		wri = NULL;
+	}
+	*wrip = wri;
+	return err;
+}
+
+void scoutfs_parallel_restore_destroy_writer(struct scoutfs_parallel_restore_writer **wrip)
+{
+	struct scoutfs_parallel_restore_writer *wri = *wrip;
+	struct extent_head *eh;
+	struct extent_head *eh_tmp;
+
+	if (!wri)
+		return;
+
+	btb_destroy(&wri->root_btb);
+	btb_destroy(&wri->fs_btb);
+	btb_destroy(&wri->srch_btb);
+	btb_destroy(&wri->log_btb);
+	btb_destroy(&wri->meta_btb[0]);
+	btb_destroy(&wri->meta_btb[1]);
+	btb_destroy(&wri->data_btb);
+	sbld_destroy(&wri->srch_sbld);
+	bbld_destroy(&wri->bloom_bbld);
+
+	list_for_each_entry_safe(eh, eh_tmp, &wri->meta_extents, head) {
+		list_del_init(&eh->head);
+		free(eh);
+	}
+
+	free(wri);
+	*wrip = NULL;
+}
+
+spr_err_t scoutfs_parallel_restore_init_slices(struct scoutfs_parallel_restore_writer *wri,
+					       struct scoutfs_parallel_restore_slice *slices,
+					       int nr)
+{
+	u64 total = le64_to_cpu(wri->super.total_meta_blocks);
+	u64 start = SCOUTFS_META_DEV_START_BLKNO;
+	u64 each = (total - start) / nr;
+	int i;
+
+	if (!wri_has_super(wri))
+		return EINVAL;
+
+	for (i = 0; i < nr - 1; i++) {
+		slices[i].fsid = wri->super.hdr.fsid;
+		slices[i].meta_start = cpu_to_le64(start);
+		slices[i].meta_len = cpu_to_le64(each);
+		start += each;
+	}
+
+	slices[i].fsid = wri->super.hdr.fsid;
+	slices[i].meta_start = cpu_to_le64(start);
+	slices[i].meta_len = cpu_to_le64(total - start);
+
+	return 0;
+}
+
+spr_err_t scoutfs_parallel_restore_add_slice(struct scoutfs_parallel_restore_writer *wri,
+					     struct scoutfs_parallel_restore_slice *slice)
+{
+	wri->fsid = slice->fsid;
+
+	return meta_alloc_add(wri, le64_to_cpu(slice->meta_start), le64_to_cpu(slice->meta_len));
+}
+
+spr_err_t scoutfs_parallel_restore_get_slice(struct scoutfs_parallel_restore_writer *wri,
+					     struct scoutfs_parallel_restore_slice *slice)
+{
+	slice->fsid = wri->fsid;
+	slice->meta_start = cpu_to_le64(wri->meta_start);
+	slice->meta_len = cpu_to_le64(wri->meta_len);
+	return 0;
+}
+
+spr_err_t scoutfs_parallel_restore_add_inode(struct scoutfs_parallel_restore_writer *wri,
+					     struct scoutfs_parallel_restore_inode *inode)
+{
+	spr_err_t err;
+
+	if (wri_has_super(wri))
+		return EINVAL;
+
+	err = insert_inode_items(wri, inode);
+	if (err)
+		goto out;
+
+	wri->inode_count++;
+	wri->max_ino = max(wri->max_ino, inode->ino);
+	err = 0;
+out:
+	return err;
+}
+
+spr_err_t scoutfs_parallel_restore_add_entry(struct scoutfs_parallel_restore_writer *wri,
+					     struct scoutfs_parallel_restore_entry *entry)
+{
+
+	if (wri_has_super(wri))
+		return EINVAL;
+
+	return insert_entry_items(wri, entry);
+}
+
+spr_err_t scoutfs_parallel_restore_add_xattr(struct scoutfs_parallel_restore_writer *wri,
+					     struct scoutfs_parallel_restore_xattr *xattr)
+{
+	spr_err_t err;
+	int xtags;
+	u32 xat_hash;
+	u64 srch_hash;
+
+	xat_hash = crc32c(U32_MAX, xattr->name, xattr->name_len);
+	srch_hash = scoutfs_hash64(xattr->name, xattr->name_len);
+	xtags = get_xattr_tags(xattr->name, xattr->name_len);
+
+	err = insert_xattr_items(wri, xattr, xat_hash);
+	if (!err) {
+		if (xtags & XTAG_SRCH)
+			err = insert_srch_entry(&wri->srch_sbld, srch_hash, xattr->ino, xattr->pos);
+		if (!err && (xtags & XTAG_TOTL))
+			err = insert_totl_item(wri, xattr);
+	}
+
+	return err;
+}
+
+spr_err_t scoutfs_parallel_restore_get_progress(struct scoutfs_parallel_restore_writer *wri,
+						struct scoutfs_parallel_restore_progress *prog)
+{
+	if (wri_has_super(wri))
+		return EINVAL;
+
+	memset(prog, 0, sizeof(struct scoutfs_parallel_restore_progress));
+	prog->fs_items = wri->fs_btb.btroot;
+	prog->root_items = wri->root_btb.btroot;
+	prog->sfl = wri->srch_sbld.sfl;
+	prog->bloom_ref.blkno = wri->bloom_bbld.bloom->hdr.blkno;
+	prog->bloom_ref.seq = wri->bloom_bbld.bloom->hdr.seq;
+	prog->inode_count = cpu_to_le64(wri->inode_count);
+	prog->max_ino = cpu_to_le64(wri->max_ino);
+
+	reset_builders(wri);
+	wri->inode_count = 0;
+	wri->max_ino = 0;
+
+	return 0;
+}
+
+spr_err_t scoutfs_parallel_restore_add_progress(struct scoutfs_parallel_restore_writer *wri,
+						struct scoutfs_parallel_restore_progress *prog)
+{
+	spr_err_t err;
+
+	if (!wri_has_super(wri))
+		return EINVAL;
+
+	/*
+	 * Only one writer's progress should contain the root inode.
+	 */
+	if (prog->root_items.ref.blkno) {
+		if (wri->root_items.ref.blkno)
+			return EEXIST;
+		wri->root_items = prog->root_items;
+	}
+
+	wri->max_ino = max(wri->max_ino, le64_to_cpu(prog->max_ino));
+
+	err = insert_log_trees_item(wri, prog);
+	if (!err && prog->sfl.ref.blkno)
+	      err = insert_srch_item(wri, &prog->sfl);
+
+	return err;
+}
+
+spr_err_t scoutfs_parallel_restore_write_buf(struct scoutfs_parallel_restore_writer *wri,
+					     void *buf, size_t len, off_t *off_ret,
+					     size_t *count_ret)
+{
+	struct block_builder *bld;
+	off_t count = 0;
+	off_t off = 0;
+	u64 blkno = 0;
+	spr_err_t err;
+
+	if (len < SCOUTFS_BLOCK_LG_SIZE) {
+		err = EINVAL;
+		goto out;
+	}
+
+	while (len >= SCOUTFS_BLOCK_LG_SIZE) {
+		bld = list_first_entry_or_null(&wri->builders, struct block_builder, head);
+		if (!bld) {
+			err = 0;
+			break;
+		}
+
+		if (bld->empty(bld)) {
+			if (bld->post && ((err = bld->post(wri, bld))))
+				break;
+			list_del_init(&bld->head);
+			continue;
+		}
+
+		err = meta_alloc_contig(wri, blkno, &blkno);
+		if (err || blkno == 0)
+			break;
+
+		if (off == 0)
+			off = blkno << SCOUTFS_BLOCK_LG_SHIFT;
+
+		err = bld->build(wri, bld, buf, blkno);
+		if (err)
+			break;
+
+		buf += SCOUTFS_BLOCK_LG_SIZE;
+		len -= SCOUTFS_BLOCK_LG_SIZE;
+		count += SCOUTFS_BLOCK_LG_SIZE;
+
+		dprintf("built blkno %llu off %llu count %llu\n", blkno, (u64)off, (u64)count);
+	}
+
+out:
+	*off_ret = off;
+	*count_ret = count;
+	return count > 0 ? 0 : err;
+}
+
+spr_err_t scoutfs_parallel_restore_import_super(struct scoutfs_parallel_restore_writer *wri,
+						struct scoutfs_super_block *super)
+{
+	spr_err_t err;
+	u64 start;
+	u64 len;
+
+	if (wri_has_super(wri))
+		return EINVAL;
+
+	start = SCOUTFS_DATA_DEV_START_BLKNO;
+	len = le64_to_cpu(super->total_data_blocks) - start;
+
+	/* make sure all data extents are free */
+	if (le64_to_cpu(super->data_alloc.total_len) != len)
+		return ENOTEMPTY;
+
+	/* we write new allocator blocks so that we don't have to read exiting */
+	err = insert_free_items(&wri->data_btb, start, len);
+	if (err)
+		return err;
+
+	wri->super = *super;
+
+	/* prepare alloc block builders only after other metadata blocks are built */
+	wri->log_btb.bld.post = prepare_alloc_builders;
+
+	return 0;
+}
+
+spr_err_t scoutfs_parallel_restore_export_super(struct scoutfs_parallel_restore_writer *wri,
+						struct scoutfs_super_block *super)
+{
+	if (!wri_has_super(wri))
+		return EINVAL;
+
+	*super = wri->super;
+
+	super->seq = le64_to_cpu(wri->max_ino + 1);
+	super->next_ino = le64_to_cpu(wri->max_ino + 1);
+	super->inode_count = le64_to_cpu(wri->inode_count);
+	set_alloc_root(&super->meta_alloc[0], &wri->meta_btb[0]);
+	set_alloc_root(&super->meta_alloc[1], &wri->meta_btb[1]);
+	set_alloc_root(&super->data_alloc, &wri->data_btb);
+	super->server_meta_avail[0] = wri->meta_alb[0].lhead;
+	super->server_meta_avail[1] = wri->meta_alb[1].lhead;
+	memset(super->server_meta_freed, 0, sizeof(super->server_meta_freed));
+	super->fs_root = wri->root_items;
+	super->logs_root = wri->log_btb.btroot;
+	memset(&super->log_merge, 0, sizeof(super->log_merge));
+	memset(&super->mounted_clients, 0, sizeof(super->mounted_clients));
+	super->srch_root = wri->srch_btb.btroot;
+	/* test volopt? */
+
+	super->hdr.crc = cpu_to_le32(crc_block(&super->hdr, SCOUTFS_BLOCK_SM_SIZE));
+
+	return 0;
+}

--- a/utils/src/parallel_restore.c
+++ b/utils/src/parallel_restore.c
@@ -664,8 +664,14 @@ static spr_err_t insert_symlink_items(struct scoutfs_parallel_restore_writer *wr
 		bti->key = key;
 		memcpy(bti->val, target + off, bytes);
 
+		err = insert_fs_item(wri, bti);
+		if (err) {
+			free(bti);
+			goto out;
+		}
+
 		off += bytes;
-		key._sk_second++;
+		le64_add_cpu(&key._sk_second, 1);
 	}
 
 	err = 0;

--- a/utils/src/parallel_restore.c
+++ b/utils/src/parallel_restore.c
@@ -804,8 +804,8 @@ static spr_err_t insert_inode_items(struct scoutfs_parallel_restore_writer *wri,
 	si = bti->val;
 
 	si->size = 0;
-	si->meta_seq = cpu_to_le64(inode->ino);
-	si->data_seq = 0;
+	si->meta_seq = cpu_to_le64(inode->meta_seq);
+	si->data_seq = cpu_to_le64(inode->data_seq);
 	si->data_version = 0;
 	si->online_blocks = 0;
 	si->offline_blocks = 0;
@@ -836,7 +836,7 @@ static spr_err_t insert_inode_items(struct scoutfs_parallel_restore_writer *wri,
 	if (S_ISREG(inode->mode)) {
 		si->size = cpu_to_le64(inode->size);
 		si->data_version = le64_to_cpu(inode->data_version);
-		si->data_seq = cpu_to_le64(inode->ino);
+		si->data_seq = cpu_to_le64(inode->data_seq);
 
 		err = insert_inode_index_item(wri, SCOUTFS_INODE_INDEX_DATA_SEQ_TYPE,
 					      le64_to_cpu(si->data_seq), inode->ino);

--- a/utils/src/parallel_restore.c
+++ b/utils/src/parallel_restore.c
@@ -1122,6 +1122,12 @@ static void btb_init(struct btree_builder *btb)
 }
 
 /*
+ * We have to reserve some space (5%) so there are enough free blocks after
+ * mounting for log_merge to complete
+ */
+#define EXTRA_BLOCK_SLICE 20;
+
+/*
  * This is how we get around the recursion of allocating blocks to write blocks that
  * store the allocators.  After we've written all other metadata blocks we know precisely
  * how many allocation blocks we'll need.  We modify the writer to only have that many
@@ -1137,6 +1143,8 @@ static spr_err_t prepare_alloc_builders(struct scoutfs_parallel_restore_writer *
 	u64 start;
 	u64 skip;
 	u64 len;
+	u64 end;
+	u64 extra;
 	int ind;
 
 	dprintf("starting prepare with start %llu len %llu\n", wri->meta_start, wri->meta_len);
@@ -1152,6 +1160,13 @@ static spr_err_t prepare_alloc_builders(struct scoutfs_parallel_restore_writer *
 	if (err)
 		goto out;
 	wri->meta_len -= len;
+	/* store reserved extra space a free extent*/
+	end = start + len;
+	extra = le64_to_cpu(wri->super.total_meta_blocks) / EXTRA_BLOCK_SLICE;
+	err = insert_free_items(&wri->meta_btb[0], end, extra);
+	if (err)
+		goto out;
+	wri->meta_len -= extra;
 
 	/* the rest of the meta extents are items in the two meta trees */
 	ind = 1;
@@ -1627,6 +1642,8 @@ spr_err_t scoutfs_parallel_restore_init_slices(struct scoutfs_parallel_restore_w
 					       int nr)
 {
 	u64 total = le64_to_cpu(wri->super.total_meta_blocks);
+	total -= total / EXTRA_BLOCK_SLICE;
+
 	u64 start = SCOUTFS_META_DEV_START_BLKNO;
 	u64 each = (total - start) / nr;
 	int i;

--- a/utils/src/parallel_restore.h
+++ b/utils/src/parallel_restore.h
@@ -1,0 +1,103 @@
+#ifndef _SCOUTFS_PARALLEL_RESTORE_H_
+#define _SCOUTFS_PARALLEL_RESTORE_H_
+
+#include <errno.h>
+
+struct scoutfs_parallel_restore_progress {
+	struct scoutfs_btree_root fs_items;
+	struct scoutfs_btree_root root_items;
+	struct scoutfs_srch_file sfl;
+	struct scoutfs_block_ref bloom_ref;
+	__le64 inode_count;
+	__le64 max_ino;
+};
+
+struct scoutfs_parallel_restore_slice {
+	__le64 fsid;
+	__le64 meta_start;
+	__le64 meta_len;
+};
+
+struct scoutfs_parallel_restore_entry {
+	u64 dir_ino;
+	u64 pos;
+	u64 ino;
+	mode_t mode;
+	char *name;
+	unsigned int name_len;
+};
+
+struct scoutfs_parallel_restore_xattr {
+	u64 ino;
+	u64 pos;
+	char *name;
+	unsigned int name_len;
+	void *value;
+	unsigned int value_len;
+};
+
+struct scoutfs_parallel_restore_inode {
+	/* all inodes */
+	u64 ino;
+	u64 nr_xattrs;
+	u32 uid;
+	u32 gid;
+	u32 mode;
+	u32 rdev;
+	struct timespec atime;
+	struct timespec ctime;
+	struct timespec mtime;
+	struct timespec crtime;
+
+	/* regular files */
+	u64 data_version;
+	u64 size;
+	bool offline;
+
+	/* only used for directories */
+	u64 nr_subdirs;
+	u64 total_entry_name_bytes;
+
+	/* only used for symlnks */
+	char *target;
+	unsigned int target_len; /* not including null terminator */
+};
+
+typedef __typeof__(EINVAL) spr_err_t;
+
+struct scoutfs_parallel_restore_writer;
+
+spr_err_t scoutfs_parallel_restore_create_writer(struct scoutfs_parallel_restore_writer **wrip);
+void scoutfs_parallel_restore_destroy_writer(struct scoutfs_parallel_restore_writer **wrip);
+
+spr_err_t scoutfs_parallel_restore_init_slices(struct scoutfs_parallel_restore_writer *wri,
+					       struct scoutfs_parallel_restore_slice *slices,
+					       int nr);
+spr_err_t scoutfs_parallel_restore_add_slice(struct scoutfs_parallel_restore_writer *wri,
+					    struct scoutfs_parallel_restore_slice *slice);
+spr_err_t scoutfs_parallel_restore_get_slice(struct scoutfs_parallel_restore_writer *wri,
+					    struct scoutfs_parallel_restore_slice *slice);
+
+spr_err_t scoutfs_parallel_restore_add_inode(struct scoutfs_parallel_restore_writer *wri,
+					     struct scoutfs_parallel_restore_inode *inode);
+spr_err_t scoutfs_parallel_restore_add_entry(struct scoutfs_parallel_restore_writer *wri,
+					     struct scoutfs_parallel_restore_entry *entry);
+spr_err_t scoutfs_parallel_restore_add_xattr(struct scoutfs_parallel_restore_writer *wri,
+					     struct scoutfs_parallel_restore_xattr *xattr);
+
+spr_err_t scoutfs_parallel_restore_get_progress(struct scoutfs_parallel_restore_writer *wri,
+						struct scoutfs_parallel_restore_progress *prog);
+spr_err_t scoutfs_parallel_restore_add_progress(struct scoutfs_parallel_restore_writer *wri,
+						struct scoutfs_parallel_restore_progress *prog);
+
+spr_err_t scoutfs_parallel_restore_write_buf(struct scoutfs_parallel_restore_writer *wri,
+					     void *buf, size_t len, off_t *off_ret,
+					     size_t *count_ret);
+
+spr_err_t scoutfs_parallel_restore_import_super(struct scoutfs_parallel_restore_writer *wri,
+						struct scoutfs_super_block *super);
+spr_err_t scoutfs_parallel_restore_export_super(struct scoutfs_parallel_restore_writer *wri,
+						struct scoutfs_super_block *super);
+
+
+#endif

--- a/utils/src/parallel_restore.h
+++ b/utils/src/parallel_restore.h
@@ -39,6 +39,8 @@ struct scoutfs_parallel_restore_xattr {
 struct scoutfs_parallel_restore_inode {
 	/* all inodes */
 	u64 ino;
+	u64 meta_seq;
+	u64 data_seq;
 	u64 nr_xattrs;
 	u32 uid;
 	u32 gid;

--- a/utils/src/rbtree.c
+++ b/utils/src/rbtree.c
@@ -1,0 +1,629 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+  Red Black Trees
+  (C) 1999  Andrea Arcangeli <andrea@suse.de>
+  (C) 2002  David Woodhouse <dwmw2@infradead.org>
+  (C) 2012  Michel Lespinasse <walken@google.com>
+
+
+  linux/lib/rbtree.c
+*/
+
+#include "lk_rbtree_wrapper.h"
+
+/*
+ * red-black trees properties:  https://en.wikipedia.org/wiki/Rbtree
+ *
+ *  1) A node is either red or black
+ *  2) The root is black
+ *  3) All leaves (NULL) are black
+ *  4) Both children of every red node are black
+ *  5) Every simple path from root to leaves contains the same number
+ *     of black nodes.
+ *
+ *  4 and 5 give the O(log n) guarantee, since 4 implies you cannot have two
+ *  consecutive red nodes in a path and every red node is therefore followed by
+ *  a black. So if B is the number of black nodes on every simple path (as per
+ *  5), then the longest possible path due to 4 is 2B.
+ *
+ *  We shall indicate color with case, where black nodes are uppercase and red
+ *  nodes will be lowercase. Unknown color nodes shall be drawn as red within
+ *  parentheses and have some accompanying text comment.
+ */
+
+/*
+ * Notes on lockless lookups:
+ *
+ * All stores to the tree structure (rb_left and rb_right) must be done using
+ * WRITE_ONCE(). And we must not inadvertently cause (temporary) loops in the
+ * tree structure as seen in program order.
+ *
+ * These two requirements will allow lockless iteration of the tree -- not
+ * correct iteration mind you, tree rotations are not atomic so a lookup might
+ * miss entire subtrees.
+ *
+ * But they do guarantee that any such traversal will only see valid elements
+ * and that it will indeed complete -- does not get stuck in a loop.
+ *
+ * It also guarantees that if the lookup returns an element it is the 'correct'
+ * one. But not returning an element does _NOT_ mean it's not present.
+ *
+ * NOTE:
+ *
+ * Stores to __rb_parent_color are not important for simple lookups so those
+ * are left undone as of now. Nor did I check for loops involving parent
+ * pointers.
+ */
+
+static inline void rb_set_black(struct rb_node *rb)
+{
+	rb->__rb_parent_color |= RB_BLACK;
+}
+
+static inline struct rb_node *rb_red_parent(struct rb_node *red)
+{
+	return (struct rb_node *)red->__rb_parent_color;
+}
+
+/*
+ * Helper function for rotations:
+ * - old's parent and color get assigned to new
+ * - old gets assigned new as a parent and 'color' as a color.
+ */
+static inline void
+__rb_rotate_set_parents(struct rb_node *old, struct rb_node *new,
+			struct rb_root *root, int color)
+{
+	struct rb_node *parent = rb_parent(old);
+	new->__rb_parent_color = old->__rb_parent_color;
+	rb_set_parent_color(old, new, color);
+	__rb_change_child(old, new, parent, root);
+}
+
+static __always_inline void
+__rb_insert(struct rb_node *node, struct rb_root *root,
+	    void (*augment_rotate)(struct rb_node *old, struct rb_node *new))
+{
+	struct rb_node *parent = rb_red_parent(node), *gparent, *tmp;
+
+	while (true) {
+		/*
+		 * Loop invariant: node is red.
+		 */
+		if (unlikely(!parent)) {
+			/*
+			 * The inserted node is root. Either this is the
+			 * first node, or we recursed at Case 1 below and
+			 * are no longer violating 4).
+			 */
+			rb_set_parent_color(node, NULL, RB_BLACK);
+			break;
+		}
+
+		/*
+		 * If there is a black parent, we are done.
+		 * Otherwise, take some corrective action as,
+		 * per 4), we don't want a red root or two
+		 * consecutive red nodes.
+		 */
+		if(rb_is_black(parent))
+			break;
+
+		gparent = rb_red_parent(parent);
+
+		tmp = gparent->rb_right;
+		if (parent != tmp) {	/* parent == gparent->rb_left */
+			if (tmp && rb_is_red(tmp)) {
+				/*
+				 * Case 1 - node's uncle is red (color flips).
+				 *
+				 *       G            g
+				 *      / \          / \
+				 *     p   u  -->   P   U
+				 *    /            /
+				 *   n            n
+				 *
+				 * However, since g's parent might be red, and
+				 * 4) does not allow this, we need to recurse
+				 * at g.
+				 */
+				rb_set_parent_color(tmp, gparent, RB_BLACK);
+				rb_set_parent_color(parent, gparent, RB_BLACK);
+				node = gparent;
+				parent = rb_parent(node);
+				rb_set_parent_color(node, parent, RB_RED);
+				continue;
+			}
+
+			tmp = parent->rb_right;
+			if (node == tmp) {
+				/*
+				 * Case 2 - node's uncle is black and node is
+				 * the parent's right child (left rotate at parent).
+				 *
+				 *      G             G
+				 *     / \           / \
+				 *    p   U  -->    n   U
+				 *     \           /
+				 *      n         p
+				 *
+				 * This still leaves us in violation of 4), the
+				 * continuation into Case 3 will fix that.
+				 */
+				tmp = node->rb_left;
+				WRITE_ONCE(parent->rb_right, tmp);
+				WRITE_ONCE(node->rb_left, parent);
+				if (tmp)
+					rb_set_parent_color(tmp, parent,
+							    RB_BLACK);
+				rb_set_parent_color(parent, node, RB_RED);
+				augment_rotate(parent, node);
+				parent = node;
+				tmp = node->rb_right;
+			}
+
+			/*
+			 * Case 3 - node's uncle is black and node is
+			 * the parent's left child (right rotate at gparent).
+			 *
+			 *        G           P
+			 *       / \         / \
+			 *      p   U  -->  n   g
+			 *     /                 \
+			 *    n                   U
+			 */
+			WRITE_ONCE(gparent->rb_left, tmp); /* == parent->rb_right */
+			WRITE_ONCE(parent->rb_right, gparent);
+			if (tmp)
+				rb_set_parent_color(tmp, gparent, RB_BLACK);
+			__rb_rotate_set_parents(gparent, parent, root, RB_RED);
+			augment_rotate(gparent, parent);
+			break;
+		} else {
+			tmp = gparent->rb_left;
+			if (tmp && rb_is_red(tmp)) {
+				/* Case 1 - color flips */
+				rb_set_parent_color(tmp, gparent, RB_BLACK);
+				rb_set_parent_color(parent, gparent, RB_BLACK);
+				node = gparent;
+				parent = rb_parent(node);
+				rb_set_parent_color(node, parent, RB_RED);
+				continue;
+			}
+
+			tmp = parent->rb_left;
+			if (node == tmp) {
+				/* Case 2 - right rotate at parent */
+				tmp = node->rb_right;
+				WRITE_ONCE(parent->rb_left, tmp);
+				WRITE_ONCE(node->rb_right, parent);
+				if (tmp)
+					rb_set_parent_color(tmp, parent,
+							    RB_BLACK);
+				rb_set_parent_color(parent, node, RB_RED);
+				augment_rotate(parent, node);
+				parent = node;
+				tmp = node->rb_left;
+			}
+
+			/* Case 3 - left rotate at gparent */
+			WRITE_ONCE(gparent->rb_right, tmp); /* == parent->rb_left */
+			WRITE_ONCE(parent->rb_left, gparent);
+			if (tmp)
+				rb_set_parent_color(tmp, gparent, RB_BLACK);
+			__rb_rotate_set_parents(gparent, parent, root, RB_RED);
+			augment_rotate(gparent, parent);
+			break;
+		}
+	}
+}
+
+/*
+ * Inline version for rb_erase() use - we want to be able to inline
+ * and eliminate the dummy_rotate callback there
+ */
+static __always_inline void
+____rb_erase_color(struct rb_node *parent, struct rb_root *root,
+	void (*augment_rotate)(struct rb_node *old, struct rb_node *new))
+{
+	struct rb_node *node = NULL, *sibling, *tmp1, *tmp2;
+
+	while (true) {
+		/*
+		 * Loop invariants:
+		 * - node is black (or NULL on first iteration)
+		 * - node is not the root (parent is not NULL)
+		 * - All leaf paths going through parent and node have a
+		 *   black node count that is 1 lower than other leaf paths.
+		 */
+		sibling = parent->rb_right;
+		if (node != sibling) {	/* node == parent->rb_left */
+			if (rb_is_red(sibling)) {
+				/*
+				 * Case 1 - left rotate at parent
+				 *
+				 *     P               S
+				 *    / \             / \
+				 *   N   s    -->    p   Sr
+				 *      / \         / \
+				 *     Sl  Sr      N   Sl
+				 */
+				tmp1 = sibling->rb_left;
+				WRITE_ONCE(parent->rb_right, tmp1);
+				WRITE_ONCE(sibling->rb_left, parent);
+				rb_set_parent_color(tmp1, parent, RB_BLACK);
+				__rb_rotate_set_parents(parent, sibling, root,
+							RB_RED);
+				augment_rotate(parent, sibling);
+				sibling = tmp1;
+			}
+			tmp1 = sibling->rb_right;
+			if (!tmp1 || rb_is_black(tmp1)) {
+				tmp2 = sibling->rb_left;
+				if (!tmp2 || rb_is_black(tmp2)) {
+					/*
+					 * Case 2 - sibling color flip
+					 * (p could be either color here)
+					 *
+					 *    (p)           (p)
+					 *    / \           / \
+					 *   N   S    -->  N   s
+					 *      / \           / \
+					 *     Sl  Sr        Sl  Sr
+					 *
+					 * This leaves us violating 5) which
+					 * can be fixed by flipping p to black
+					 * if it was red, or by recursing at p.
+					 * p is red when coming from Case 1.
+					 */
+					rb_set_parent_color(sibling, parent,
+							    RB_RED);
+					if (rb_is_red(parent))
+						rb_set_black(parent);
+					else {
+						node = parent;
+						parent = rb_parent(node);
+						if (parent)
+							continue;
+					}
+					break;
+				}
+				/*
+				 * Case 3 - right rotate at sibling
+				 * (p could be either color here)
+				 *
+				 *   (p)           (p)
+				 *   / \           / \
+				 *  N   S    -->  N   sl
+				 *     / \             \
+				 *    sl  Sr            S
+				 *                       \
+				 *                        Sr
+				 *
+				 * Note: p might be red, and then both
+				 * p and sl are red after rotation(which
+				 * breaks property 4). This is fixed in
+				 * Case 4 (in __rb_rotate_set_parents()
+				 *         which set sl the color of p
+				 *         and set p RB_BLACK)
+				 *
+				 *   (p)            (sl)
+				 *   / \            /  \
+				 *  N   sl   -->   P    S
+				 *       \        /      \
+				 *        S      N        Sr
+				 *         \
+				 *          Sr
+				 */
+				tmp1 = tmp2->rb_right;
+				WRITE_ONCE(sibling->rb_left, tmp1);
+				WRITE_ONCE(tmp2->rb_right, sibling);
+				WRITE_ONCE(parent->rb_right, tmp2);
+				if (tmp1)
+					rb_set_parent_color(tmp1, sibling,
+							    RB_BLACK);
+				augment_rotate(sibling, tmp2);
+				tmp1 = sibling;
+				sibling = tmp2;
+			}
+			/*
+			 * Case 4 - left rotate at parent + color flips
+			 * (p and sl could be either color here.
+			 *  After rotation, p becomes black, s acquires
+			 *  p's color, and sl keeps its color)
+			 *
+			 *      (p)             (s)
+			 *      / \             / \
+			 *     N   S     -->   P   Sr
+			 *        / \         / \
+			 *      (sl) sr      N  (sl)
+			 */
+			tmp2 = sibling->rb_left;
+			WRITE_ONCE(parent->rb_right, tmp2);
+			WRITE_ONCE(sibling->rb_left, parent);
+			rb_set_parent_color(tmp1, sibling, RB_BLACK);
+			if (tmp2)
+				rb_set_parent(tmp2, parent);
+			__rb_rotate_set_parents(parent, sibling, root,
+						RB_BLACK);
+			augment_rotate(parent, sibling);
+			break;
+		} else {
+			sibling = parent->rb_left;
+			if (rb_is_red(sibling)) {
+				/* Case 1 - right rotate at parent */
+				tmp1 = sibling->rb_right;
+				WRITE_ONCE(parent->rb_left, tmp1);
+				WRITE_ONCE(sibling->rb_right, parent);
+				rb_set_parent_color(tmp1, parent, RB_BLACK);
+				__rb_rotate_set_parents(parent, sibling, root,
+							RB_RED);
+				augment_rotate(parent, sibling);
+				sibling = tmp1;
+			}
+			tmp1 = sibling->rb_left;
+			if (!tmp1 || rb_is_black(tmp1)) {
+				tmp2 = sibling->rb_right;
+				if (!tmp2 || rb_is_black(tmp2)) {
+					/* Case 2 - sibling color flip */
+					rb_set_parent_color(sibling, parent,
+							    RB_RED);
+					if (rb_is_red(parent))
+						rb_set_black(parent);
+					else {
+						node = parent;
+						parent = rb_parent(node);
+						if (parent)
+							continue;
+					}
+					break;
+				}
+				/* Case 3 - left rotate at sibling */
+				tmp1 = tmp2->rb_left;
+				WRITE_ONCE(sibling->rb_right, tmp1);
+				WRITE_ONCE(tmp2->rb_left, sibling);
+				WRITE_ONCE(parent->rb_left, tmp2);
+				if (tmp1)
+					rb_set_parent_color(tmp1, sibling,
+							    RB_BLACK);
+				augment_rotate(sibling, tmp2);
+				tmp1 = sibling;
+				sibling = tmp2;
+			}
+			/* Case 4 - right rotate at parent + color flips */
+			tmp2 = sibling->rb_right;
+			WRITE_ONCE(parent->rb_left, tmp2);
+			WRITE_ONCE(sibling->rb_right, parent);
+			rb_set_parent_color(tmp1, sibling, RB_BLACK);
+			if (tmp2)
+				rb_set_parent(tmp2, parent);
+			__rb_rotate_set_parents(parent, sibling, root,
+						RB_BLACK);
+			augment_rotate(parent, sibling);
+			break;
+		}
+	}
+}
+
+/* Non-inline version for rb_erase_augmented() use */
+void __rb_erase_color(struct rb_node *parent, struct rb_root *root,
+	void (*augment_rotate)(struct rb_node *old, struct rb_node *new))
+{
+	____rb_erase_color(parent, root, augment_rotate);
+}
+EXPORT_SYMBOL(__rb_erase_color);
+
+/*
+ * Non-augmented rbtree manipulation functions.
+ *
+ * We use dummy augmented callbacks here, and have the compiler optimize them
+ * out of the rb_insert_color() and rb_erase() function definitions.
+ */
+
+static inline void dummy_propagate(struct rb_node *node, struct rb_node *stop) {}
+static inline void dummy_copy(struct rb_node *old, struct rb_node *new) {}
+static inline void dummy_rotate(struct rb_node *old, struct rb_node *new) {}
+
+static const struct rb_augment_callbacks dummy_callbacks = {
+	.propagate = dummy_propagate,
+	.copy = dummy_copy,
+	.rotate = dummy_rotate
+};
+
+void rb_insert_color(struct rb_node *node, struct rb_root *root)
+{
+	__rb_insert(node, root, dummy_rotate);
+}
+EXPORT_SYMBOL(rb_insert_color);
+
+void rb_erase(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *rebalance;
+	rebalance = __rb_erase_augmented(node, root, &dummy_callbacks);
+	if (rebalance)
+		____rb_erase_color(rebalance, root, dummy_rotate);
+}
+EXPORT_SYMBOL(rb_erase);
+
+/*
+ * Augmented rbtree manipulation functions.
+ *
+ * This instantiates the same __always_inline functions as in the non-augmented
+ * case, but this time with user-defined callbacks.
+ */
+
+void __rb_insert_augmented(struct rb_node *node, struct rb_root *root,
+	void (*augment_rotate)(struct rb_node *old, struct rb_node *new))
+{
+	__rb_insert(node, root, augment_rotate);
+}
+EXPORT_SYMBOL(__rb_insert_augmented);
+
+/*
+ * This function returns the first node (in sort order) of the tree.
+ */
+struct rb_node *rb_first(const struct rb_root *root)
+{
+	struct rb_node	*n;
+
+	n = root->rb_node;
+	if (!n)
+		return NULL;
+	while (n->rb_left)
+		n = n->rb_left;
+	return n;
+}
+EXPORT_SYMBOL(rb_first);
+
+struct rb_node *rb_last(const struct rb_root *root)
+{
+	struct rb_node	*n;
+
+	n = root->rb_node;
+	if (!n)
+		return NULL;
+	while (n->rb_right)
+		n = n->rb_right;
+	return n;
+}
+EXPORT_SYMBOL(rb_last);
+
+struct rb_node *rb_next(const struct rb_node *node)
+{
+	struct rb_node *parent;
+
+	if (RB_EMPTY_NODE(node))
+		return NULL;
+
+	/*
+	 * If we have a right-hand child, go down and then left as far
+	 * as we can.
+	 */
+	if (node->rb_right) {
+		node = node->rb_right;
+		while (node->rb_left)
+			node = node->rb_left;
+		return (struct rb_node *)node;
+	}
+
+	/*
+	 * No right-hand children. Everything down and left is smaller than us,
+	 * so any 'next' node must be in the general direction of our parent.
+	 * Go up the tree; any time the ancestor is a right-hand child of its
+	 * parent, keep going up. First time it's a left-hand child of its
+	 * parent, said parent is our 'next' node.
+	 */
+	while ((parent = rb_parent(node)) && node == parent->rb_right)
+		node = parent;
+
+	return parent;
+}
+EXPORT_SYMBOL(rb_next);
+
+struct rb_node *rb_prev(const struct rb_node *node)
+{
+	struct rb_node *parent;
+
+	if (RB_EMPTY_NODE(node))
+		return NULL;
+
+	/*
+	 * If we have a left-hand child, go down and then right as far
+	 * as we can.
+	 */
+	if (node->rb_left) {
+		node = node->rb_left;
+		while (node->rb_right)
+			node = node->rb_right;
+		return (struct rb_node *)node;
+	}
+
+	/*
+	 * No left-hand children. Go up till we find an ancestor which
+	 * is a right-hand child of its parent.
+	 */
+	while ((parent = rb_parent(node)) && node == parent->rb_left)
+		node = parent;
+
+	return parent;
+}
+EXPORT_SYMBOL(rb_prev);
+
+void rb_replace_node(struct rb_node *victim, struct rb_node *new,
+		     struct rb_root *root)
+{
+	struct rb_node *parent = rb_parent(victim);
+
+	/* Copy the pointers/colour from the victim to the replacement */
+	*new = *victim;
+
+	/* Set the surrounding nodes to point to the replacement */
+	if (victim->rb_left)
+		rb_set_parent(victim->rb_left, new);
+	if (victim->rb_right)
+		rb_set_parent(victim->rb_right, new);
+	__rb_change_child(victim, new, parent, root);
+}
+EXPORT_SYMBOL(rb_replace_node);
+
+void rb_replace_node_rcu(struct rb_node *victim, struct rb_node *new,
+			 struct rb_root *root)
+{
+	struct rb_node *parent = rb_parent(victim);
+
+	/* Copy the pointers/colour from the victim to the replacement */
+	*new = *victim;
+
+	/* Set the surrounding nodes to point to the replacement */
+	if (victim->rb_left)
+		rb_set_parent(victim->rb_left, new);
+	if (victim->rb_right)
+		rb_set_parent(victim->rb_right, new);
+
+	/* Set the parent's pointer to the new node last after an RCU barrier
+	 * so that the pointers onwards are seen to be set correctly when doing
+	 * an RCU walk over the tree.
+	 */
+	__rb_change_child_rcu(victim, new, parent, root);
+}
+EXPORT_SYMBOL(rb_replace_node_rcu);
+
+static struct rb_node *rb_left_deepest_node(const struct rb_node *node)
+{
+	for (;;) {
+		if (node->rb_left)
+			node = node->rb_left;
+		else if (node->rb_right)
+			node = node->rb_right;
+		else
+			return (struct rb_node *)node;
+	}
+}
+
+struct rb_node *rb_next_postorder(const struct rb_node *node)
+{
+	const struct rb_node *parent;
+	if (!node)
+		return NULL;
+	parent = rb_parent(node);
+
+	/* If we're sitting on node, we've already seen our children */
+	if (parent && node == parent->rb_left && parent->rb_right) {
+		/* If we are the parent's left node, go to the parent's right
+		 * node then all the way down to the left */
+		return rb_left_deepest_node(parent->rb_right);
+	} else
+		/* Otherwise we are the parent's right node, and the parent
+		 * should be next */
+		return (struct rb_node *)parent;
+}
+EXPORT_SYMBOL(rb_next_postorder);
+
+struct rb_node *rb_first_postorder(const struct rb_root *root)
+{
+	if (!root->rb_node)
+		return NULL;
+
+	return rb_left_deepest_node(root->rb_node);
+}
+EXPORT_SYMBOL(rb_first_postorder);

--- a/utils/src/rbtree.h
+++ b/utils/src/rbtree.h
@@ -1,0 +1,328 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+  Red Black Trees
+  (C) 1999  Andrea Arcangeli <andrea@suse.de>
+  
+
+  linux/include/linux/rbtree.h
+
+  To use rbtrees you'll have to implement your own insert and search cores.
+  This will avoid us to use callbacks and to drop drammatically performances.
+  I know it's not the cleaner way,  but in C (not in C++) to get
+  performances and genericity...
+
+  See Documentation/core-api/rbtree.rst for documentation and samples.
+*/
+
+#ifndef	_LINUX_RBTREE_H
+#define	_LINUX_RBTREE_H
+
+#define rb_parent(r)   ((struct rb_node *)((r)->__rb_parent_color & ~3))
+
+#define	rb_entry(ptr, type, member) container_of(ptr, type, member)
+
+#define RB_EMPTY_ROOT(root)  (READ_ONCE((root)->rb_node) == NULL)
+
+/* 'empty' nodes are nodes that are known not to be inserted in an rbtree */
+#define RB_EMPTY_NODE(node)  \
+	((node)->__rb_parent_color == (unsigned long)(node))
+#define RB_CLEAR_NODE(node)  \
+	((node)->__rb_parent_color = (unsigned long)(node))
+
+
+extern void rb_insert_color(struct rb_node *, struct rb_root *);
+extern void rb_erase(struct rb_node *, struct rb_root *);
+
+
+/* Find logical next and previous nodes in a tree */
+extern struct rb_node *rb_next(const struct rb_node *);
+extern struct rb_node *rb_prev(const struct rb_node *);
+extern struct rb_node *rb_first(const struct rb_root *);
+extern struct rb_node *rb_last(const struct rb_root *);
+
+/* Postorder iteration - always visit the parent after its children */
+extern struct rb_node *rb_first_postorder(const struct rb_root *);
+extern struct rb_node *rb_next_postorder(const struct rb_node *);
+
+/* Fast replacement of a single node without remove/rebalance/add/rebalance */
+extern void rb_replace_node(struct rb_node *victim, struct rb_node *new,
+			    struct rb_root *root);
+extern void rb_replace_node_rcu(struct rb_node *victim, struct rb_node *new,
+				struct rb_root *root);
+
+static inline void rb_link_node(struct rb_node *node, struct rb_node *parent,
+				struct rb_node **rb_link)
+{
+	node->__rb_parent_color = (unsigned long)parent;
+	node->rb_left = node->rb_right = NULL;
+
+	*rb_link = node;
+}
+
+static inline void rb_link_node_rcu(struct rb_node *node, struct rb_node *parent,
+				    struct rb_node **rb_link)
+{
+	node->__rb_parent_color = (unsigned long)parent;
+	node->rb_left = node->rb_right = NULL;
+
+	rcu_assign_pointer(*rb_link, node);
+}
+
+#define rb_entry_safe(ptr, type, member) \
+	({ typeof(ptr) ____ptr = (ptr); \
+	   ____ptr ? rb_entry(____ptr, type, member) : NULL; \
+	})
+
+/**
+ * rbtree_postorder_for_each_entry_safe - iterate in post-order over rb_root of
+ * given type allowing the backing memory of @pos to be invalidated
+ *
+ * @pos:	the 'type *' to use as a loop cursor.
+ * @n:		another 'type *' to use as temporary storage
+ * @root:	'rb_root *' of the rbtree.
+ * @field:	the name of the rb_node field within 'type'.
+ *
+ * rbtree_postorder_for_each_entry_safe() provides a similar guarantee as
+ * list_for_each_entry_safe() and allows the iteration to continue independent
+ * of changes to @pos by the body of the loop.
+ *
+ * Note, however, that it cannot handle other modifications that re-order the
+ * rbtree it is iterating over. This includes calling rb_erase() on @pos, as
+ * rb_erase() may rebalance the tree, causing us to miss some nodes.
+ */
+#define rbtree_postorder_for_each_entry_safe(pos, n, root, field) \
+	for (pos = rb_entry_safe(rb_first_postorder(root), typeof(*pos), field); \
+	     pos && ({ n = rb_entry_safe(rb_next_postorder(&pos->field), \
+			typeof(*pos), field); 1; }); \
+	     pos = n)
+
+/* Same as rb_first(), but O(1) */
+#define rb_first_cached(root) (root)->rb_leftmost
+
+static inline void rb_insert_color_cached(struct rb_node *node,
+					  struct rb_root_cached *root,
+					  bool leftmost)
+{
+	if (leftmost)
+		root->rb_leftmost = node;
+	rb_insert_color(node, &root->rb_root);
+}
+
+
+static inline struct rb_node *
+rb_erase_cached(struct rb_node *node, struct rb_root_cached *root)
+{
+	struct rb_node *leftmost = NULL;
+
+	if (root->rb_leftmost == node)
+		leftmost = root->rb_leftmost = rb_next(node);
+
+	rb_erase(node, &root->rb_root);
+
+	return leftmost;
+}
+
+static inline void rb_replace_node_cached(struct rb_node *victim,
+					  struct rb_node *new,
+					  struct rb_root_cached *root)
+{
+	if (root->rb_leftmost == victim)
+		root->rb_leftmost = new;
+	rb_replace_node(victim, new, &root->rb_root);
+}
+
+/*
+ * The below helper functions use 2 operators with 3 different
+ * calling conventions. The operators are related like:
+ *
+ *	comp(a->key,b) < 0  := less(a,b)
+ *	comp(a->key,b) > 0  := less(b,a)
+ *	comp(a->key,b) == 0 := !less(a,b) && !less(b,a)
+ *
+ * If these operators define a partial order on the elements we make no
+ * guarantee on which of the elements matching the key is found. See
+ * rb_find().
+ *
+ * The reason for this is to allow the find() interface without requiring an
+ * on-stack dummy object, which might not be feasible due to object size.
+ */
+
+/**
+ * rb_add_cached() - insert @node into the leftmost cached tree @tree
+ * @node: node to insert
+ * @tree: leftmost cached tree to insert @node into
+ * @less: operator defining the (partial) node order
+ *
+ * Returns @node when it is the new leftmost, or NULL.
+ */
+static __always_inline struct rb_node *
+rb_add_cached(struct rb_node *node, struct rb_root_cached *tree,
+	      bool (*less)(struct rb_node *, const struct rb_node *))
+{
+	struct rb_node **link = &tree->rb_root.rb_node;
+	struct rb_node *parent = NULL;
+	bool leftmost = true;
+
+	while (*link) {
+		parent = *link;
+		if (less(node, parent)) {
+			link = &parent->rb_left;
+		} else {
+			link = &parent->rb_right;
+			leftmost = false;
+		}
+	}
+
+	rb_link_node(node, parent, link);
+	rb_insert_color_cached(node, tree, leftmost);
+
+	return leftmost ? node : NULL;
+}
+
+/**
+ * rb_add() - insert @node into @tree
+ * @node: node to insert
+ * @tree: tree to insert @node into
+ * @less: operator defining the (partial) node order
+ */
+static __always_inline void
+rb_add(struct rb_node *node, struct rb_root *tree,
+       bool (*less)(struct rb_node *, const struct rb_node *))
+{
+	struct rb_node **link = &tree->rb_node;
+	struct rb_node *parent = NULL;
+
+	while (*link) {
+		parent = *link;
+		if (less(node, parent))
+			link = &parent->rb_left;
+		else
+			link = &parent->rb_right;
+	}
+
+	rb_link_node(node, parent, link);
+	rb_insert_color(node, tree);
+}
+
+/**
+ * rb_find_add() - find equivalent @node in @tree, or add @node
+ * @node: node to look-for / insert
+ * @tree: tree to search / modify
+ * @cmp: operator defining the node order
+ *
+ * Returns the rb_node matching @node, or NULL when no match is found and @node
+ * is inserted.
+ */
+static __always_inline struct rb_node *
+rb_find_add(struct rb_node *node, struct rb_root *tree,
+	    int (*cmp)(struct rb_node *, const struct rb_node *))
+{
+	struct rb_node **link = &tree->rb_node;
+	struct rb_node *parent = NULL;
+	int c;
+
+	while (*link) {
+		parent = *link;
+		c = cmp(node, parent);
+
+		if (c < 0)
+			link = &parent->rb_left;
+		else if (c > 0)
+			link = &parent->rb_right;
+		else
+			return parent;
+	}
+
+	rb_link_node(node, parent, link);
+	rb_insert_color(node, tree);
+	return NULL;
+}
+
+/**
+ * rb_find() - find @key in tree @tree
+ * @key: key to match
+ * @tree: tree to search
+ * @cmp: operator defining the node order
+ *
+ * Returns the rb_node matching @key or NULL.
+ */
+static __always_inline struct rb_node *
+rb_find(const void *key, const struct rb_root *tree,
+	int (*cmp)(const void *key, const struct rb_node *))
+{
+	struct rb_node *node = tree->rb_node;
+
+	while (node) {
+		int c = cmp(key, node);
+
+		if (c < 0)
+			node = node->rb_left;
+		else if (c > 0)
+			node = node->rb_right;
+		else
+			return node;
+	}
+
+	return NULL;
+}
+
+/**
+ * rb_find_first() - find the first @key in @tree
+ * @key: key to match
+ * @tree: tree to search
+ * @cmp: operator defining node order
+ *
+ * Returns the leftmost node matching @key, or NULL.
+ */
+static __always_inline struct rb_node *
+rb_find_first(const void *key, const struct rb_root *tree,
+	      int (*cmp)(const void *key, const struct rb_node *))
+{
+	struct rb_node *node = tree->rb_node;
+	struct rb_node *match = NULL;
+
+	while (node) {
+		int c = cmp(key, node);
+
+		if (c <= 0) {
+			if (!c)
+				match = node;
+			node = node->rb_left;
+		} else if (c > 0) {
+			node = node->rb_right;
+		}
+	}
+
+	return match;
+}
+
+/**
+ * rb_next_match() - find the next @key in @tree
+ * @key: key to match
+ * @tree: tree to search
+ * @cmp: operator defining node order
+ *
+ * Returns the next node matching @key, or NULL.
+ */
+static __always_inline struct rb_node *
+rb_next_match(const void *key, struct rb_node *node,
+	      int (*cmp)(const void *key, const struct rb_node *))
+{
+	node = rb_next(node);
+	if (node && cmp(key, node))
+		node = NULL;
+	return node;
+}
+
+/**
+ * rb_for_each() - iterates a subtree matching @key
+ * @node: iterator
+ * @key: key to match
+ * @tree: tree to search
+ * @cmp: operator defining node order
+ */
+#define rb_for_each(node, key, tree, cmp) \
+	for ((node) = rb_find_first((key), (tree), (cmp)); \
+	     (node); (node) = rb_next_match((key), (node), (cmp)))
+
+#endif	/* _LINUX_RBTREE_H */

--- a/utils/src/rbtree_augmented.h
+++ b/utils/src/rbtree_augmented.h
@@ -1,0 +1,313 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+  Red Black Trees
+  (C) 1999  Andrea Arcangeli <andrea@suse.de>
+  (C) 2002  David Woodhouse <dwmw2@infradead.org>
+  (C) 2012  Michel Lespinasse <walken@google.com>
+
+
+  linux/include/linux/rbtree_augmented.h
+*/
+
+#ifndef _LINUX_RBTREE_AUGMENTED_H
+#define _LINUX_RBTREE_AUGMENTED_H
+
+/*
+ * Please note - only struct rb_augment_callbacks and the prototypes for
+ * rb_insert_augmented() and rb_erase_augmented() are intended to be public.
+ * The rest are implementation details you are not expected to depend on.
+ *
+ * See Documentation/core-api/rbtree.rst for documentation and samples.
+ */
+
+struct rb_augment_callbacks {
+	void (*propagate)(struct rb_node *node, struct rb_node *stop);
+	void (*copy)(struct rb_node *old, struct rb_node *new);
+	void (*rotate)(struct rb_node *old, struct rb_node *new);
+};
+
+extern void __rb_insert_augmented(struct rb_node *node, struct rb_root *root,
+	void (*augment_rotate)(struct rb_node *old, struct rb_node *new));
+
+/*
+ * Fixup the rbtree and update the augmented information when rebalancing.
+ *
+ * On insertion, the user must update the augmented information on the path
+ * leading to the inserted node, then call rb_link_node() as usual and
+ * rb_insert_augmented() instead of the usual rb_insert_color() call.
+ * If rb_insert_augmented() rebalances the rbtree, it will callback into
+ * a user provided function to update the augmented information on the
+ * affected subtrees.
+ */
+static inline void
+rb_insert_augmented(struct rb_node *node, struct rb_root *root,
+		    const struct rb_augment_callbacks *augment)
+{
+	__rb_insert_augmented(node, root, augment->rotate);
+}
+
+static inline void
+rb_insert_augmented_cached(struct rb_node *node,
+			   struct rb_root_cached *root, bool newleft,
+			   const struct rb_augment_callbacks *augment)
+{
+	if (newleft)
+		root->rb_leftmost = node;
+	rb_insert_augmented(node, &root->rb_root, augment);
+}
+
+/*
+ * Template for declaring augmented rbtree callbacks (generic case)
+ *
+ * RBSTATIC:    'static' or empty
+ * RBNAME:      name of the rb_augment_callbacks structure
+ * RBSTRUCT:    struct type of the tree nodes
+ * RBFIELD:     name of struct rb_node field within RBSTRUCT
+ * RBAUGMENTED: name of field within RBSTRUCT holding data for subtree
+ * RBCOMPUTE:   name of function that recomputes the RBAUGMENTED data
+ */
+
+#define RB_DECLARE_CALLBACKS(RBSTATIC, RBNAME,				\
+			     RBSTRUCT, RBFIELD, RBAUGMENTED, RBCOMPUTE)	\
+static inline void							\
+RBNAME ## _propagate(struct rb_node *rb, struct rb_node *stop)		\
+{									\
+	while (rb != stop) {						\
+		RBSTRUCT *node = rb_entry(rb, RBSTRUCT, RBFIELD);	\
+		if (RBCOMPUTE(node, true))				\
+			break;						\
+		rb = rb_parent(&node->RBFIELD);				\
+	}								\
+}									\
+static inline void							\
+RBNAME ## _copy(struct rb_node *rb_old, struct rb_node *rb_new)		\
+{									\
+	RBSTRUCT *old = rb_entry(rb_old, RBSTRUCT, RBFIELD);		\
+	RBSTRUCT *new = rb_entry(rb_new, RBSTRUCT, RBFIELD);		\
+	new->RBAUGMENTED = old->RBAUGMENTED;				\
+}									\
+static void								\
+RBNAME ## _rotate(struct rb_node *rb_old, struct rb_node *rb_new)	\
+{									\
+	RBSTRUCT *old = rb_entry(rb_old, RBSTRUCT, RBFIELD);		\
+	RBSTRUCT *new = rb_entry(rb_new, RBSTRUCT, RBFIELD);		\
+	new->RBAUGMENTED = old->RBAUGMENTED;				\
+	RBCOMPUTE(old, false);						\
+}									\
+RBSTATIC const struct rb_augment_callbacks RBNAME = {			\
+	.propagate = RBNAME ## _propagate,				\
+	.copy = RBNAME ## _copy,					\
+	.rotate = RBNAME ## _rotate					\
+};
+
+/*
+ * Template for declaring augmented rbtree callbacks,
+ * computing RBAUGMENTED scalar as max(RBCOMPUTE(node)) for all subtree nodes.
+ *
+ * RBSTATIC:    'static' or empty
+ * RBNAME:      name of the rb_augment_callbacks structure
+ * RBSTRUCT:    struct type of the tree nodes
+ * RBFIELD:     name of struct rb_node field within RBSTRUCT
+ * RBTYPE:      type of the RBAUGMENTED field
+ * RBAUGMENTED: name of RBTYPE field within RBSTRUCT holding data for subtree
+ * RBCOMPUTE:   name of function that returns the per-node RBTYPE scalar
+ */
+
+#define RB_DECLARE_CALLBACKS_MAX(RBSTATIC, RBNAME, RBSTRUCT, RBFIELD,	      \
+				 RBTYPE, RBAUGMENTED, RBCOMPUTE)	      \
+static inline bool RBNAME ## _compute_max(RBSTRUCT *node, bool exit)	      \
+{									      \
+	RBSTRUCT *child;						      \
+	RBTYPE max = RBCOMPUTE(node);					      \
+	if (node->RBFIELD.rb_left) {					      \
+		child = rb_entry(node->RBFIELD.rb_left, RBSTRUCT, RBFIELD);   \
+		if (child->RBAUGMENTED > max)				      \
+			max = child->RBAUGMENTED;			      \
+	}								      \
+	if (node->RBFIELD.rb_right) {					      \
+		child = rb_entry(node->RBFIELD.rb_right, RBSTRUCT, RBFIELD);  \
+		if (child->RBAUGMENTED > max)				      \
+			max = child->RBAUGMENTED;			      \
+	}								      \
+	if (exit && node->RBAUGMENTED == max)				      \
+		return true;						      \
+	node->RBAUGMENTED = max;					      \
+	return false;							      \
+}									      \
+RB_DECLARE_CALLBACKS(RBSTATIC, RBNAME,					      \
+		     RBSTRUCT, RBFIELD, RBAUGMENTED, RBNAME ## _compute_max)
+
+
+#define	RB_RED		0
+#define	RB_BLACK	1
+
+#define __rb_parent(pc)    ((struct rb_node *)(pc & ~3))
+
+#define __rb_color(pc)     ((pc) & 1)
+#define __rb_is_black(pc)  __rb_color(pc)
+#define __rb_is_red(pc)    (!__rb_color(pc))
+#define rb_color(rb)       __rb_color((rb)->__rb_parent_color)
+#define rb_is_red(rb)      __rb_is_red((rb)->__rb_parent_color)
+#define rb_is_black(rb)    __rb_is_black((rb)->__rb_parent_color)
+
+static inline void rb_set_parent(struct rb_node *rb, struct rb_node *p)
+{
+	rb->__rb_parent_color = rb_color(rb) | (unsigned long)p;
+}
+
+static inline void rb_set_parent_color(struct rb_node *rb,
+				       struct rb_node *p, int color)
+{
+	rb->__rb_parent_color = (unsigned long)p | color;
+}
+
+static inline void
+__rb_change_child(struct rb_node *old, struct rb_node *new,
+		  struct rb_node *parent, struct rb_root *root)
+{
+	if (parent) {
+		if (parent->rb_left == old)
+			WRITE_ONCE(parent->rb_left, new);
+		else
+			WRITE_ONCE(parent->rb_right, new);
+	} else
+		WRITE_ONCE(root->rb_node, new);
+}
+
+static inline void
+__rb_change_child_rcu(struct rb_node *old, struct rb_node *new,
+		      struct rb_node *parent, struct rb_root *root)
+{
+	if (parent) {
+		if (parent->rb_left == old)
+			rcu_assign_pointer(parent->rb_left, new);
+		else
+			rcu_assign_pointer(parent->rb_right, new);
+	} else
+		rcu_assign_pointer(root->rb_node, new);
+}
+
+extern void __rb_erase_color(struct rb_node *parent, struct rb_root *root,
+	void (*augment_rotate)(struct rb_node *old, struct rb_node *new));
+
+static __always_inline struct rb_node *
+__rb_erase_augmented(struct rb_node *node, struct rb_root *root,
+		     const struct rb_augment_callbacks *augment)
+{
+	struct rb_node *child = node->rb_right;
+	struct rb_node *tmp = node->rb_left;
+	struct rb_node *parent, *rebalance;
+	unsigned long pc;
+
+	if (!tmp) {
+		/*
+		 * Case 1: node to erase has no more than 1 child (easy!)
+		 *
+		 * Note that if there is one child it must be red due to 5)
+		 * and node must be black due to 4). We adjust colors locally
+		 * so as to bypass __rb_erase_color() later on.
+		 */
+		pc = node->__rb_parent_color;
+		parent = __rb_parent(pc);
+		__rb_change_child(node, child, parent, root);
+		if (child) {
+			child->__rb_parent_color = pc;
+			rebalance = NULL;
+		} else
+			rebalance = __rb_is_black(pc) ? parent : NULL;
+		tmp = parent;
+	} else if (!child) {
+		/* Still case 1, but this time the child is node->rb_left */
+		tmp->__rb_parent_color = pc = node->__rb_parent_color;
+		parent = __rb_parent(pc);
+		__rb_change_child(node, tmp, parent, root);
+		rebalance = NULL;
+		tmp = parent;
+	} else {
+		struct rb_node *successor = child, *child2;
+
+		tmp = child->rb_left;
+		if (!tmp) {
+			/*
+			 * Case 2: node's successor is its right child
+			 *
+			 *    (n)          (s)
+			 *    / \          / \
+			 *  (x) (s)  ->  (x) (c)
+			 *        \
+			 *        (c)
+			 */
+			parent = successor;
+			child2 = successor->rb_right;
+
+			augment->copy(node, successor);
+		} else {
+			/*
+			 * Case 3: node's successor is leftmost under
+			 * node's right child subtree
+			 *
+			 *    (n)          (s)
+			 *    / \          / \
+			 *  (x) (y)  ->  (x) (y)
+			 *      /            /
+			 *    (p)          (p)
+			 *    /            /
+			 *  (s)          (c)
+			 *    \
+			 *    (c)
+			 */
+			do {
+				parent = successor;
+				successor = tmp;
+				tmp = tmp->rb_left;
+			} while (tmp);
+			child2 = successor->rb_right;
+			WRITE_ONCE(parent->rb_left, child2);
+			WRITE_ONCE(successor->rb_right, child);
+			rb_set_parent(child, successor);
+
+			augment->copy(node, successor);
+			augment->propagate(parent, successor);
+		}
+
+		tmp = node->rb_left;
+		WRITE_ONCE(successor->rb_left, tmp);
+		rb_set_parent(tmp, successor);
+
+		pc = node->__rb_parent_color;
+		tmp = __rb_parent(pc);
+		__rb_change_child(node, successor, tmp, root);
+
+		if (child2) {
+			rb_set_parent_color(child2, parent, RB_BLACK);
+			rebalance = NULL;
+		} else {
+			rebalance = rb_is_black(successor) ? parent : NULL;
+		}
+		successor->__rb_parent_color = pc;
+		tmp = successor;
+	}
+
+	augment->propagate(tmp, NULL);
+	return rebalance;
+}
+
+static __always_inline void
+rb_erase_augmented(struct rb_node *node, struct rb_root *root,
+		   const struct rb_augment_callbacks *augment)
+{
+	struct rb_node *rebalance = __rb_erase_augmented(node, root, augment);
+	if (rebalance)
+		__rb_erase_color(rebalance, root, augment->rotate);
+}
+
+static __always_inline void
+rb_erase_augmented_cached(struct rb_node *node, struct rb_root_cached *root,
+			  const struct rb_augment_callbacks *augment)
+{
+	if (root->rb_leftmost == node)
+		root->rb_leftmost = rb_next(node);
+	rb_erase_augmented(node, &root->rb_root, augment);
+}
+
+#endif	/* _LINUX_RBTREE_AUGMENTED_H */

--- a/utils/src/rbtree_types.h
+++ b/utils/src/rbtree_types.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef _LINUX_RBTREE_TYPES_H
+#define _LINUX_RBTREE_TYPES_H
+
+struct rb_node {
+	unsigned long  __rb_parent_color;
+	struct rb_node *rb_right;
+	struct rb_node *rb_left;
+} __attribute__((aligned(sizeof(long))));
+/* The alignment might seem pointless, but allegedly CRIS needs it */
+
+struct rb_root {
+	struct rb_node *rb_node;
+};
+
+/*
+ * Leftmost-cached rbtrees.
+ *
+ * We do not cache the rightmost node based on footprint
+ * size vs number of potential users that could benefit
+ * from O(1) rb_last(). Just not worth it, users that want
+ * this feature can always implement the logic explicitly.
+ * Furthermore, users that want to cache both pointers may
+ * find it a bit asymmetric, but that's ok.
+ */
+struct rb_root_cached {
+	struct rb_root rb_root;
+	struct rb_node *rb_leftmost;
+};
+
+#define RB_ROOT (struct rb_root) { NULL, }
+#define RB_ROOT_CACHED (struct rb_root_cached) { {NULL, }, NULL }
+
+#endif

--- a/utils/src/srch.h
+++ b/utils/src/srch.h
@@ -3,5 +3,6 @@
 
 int srch_decode_entry(void *buf, struct scoutfs_srch_entry *sre,
 		      struct scoutfs_srch_entry *prev);
+int srch_encode_entry(void *buf, struct scoutfs_srch_entry *sre, struct scoutfs_srch_entry *prev);
 
 #endif

--- a/utils/src/util.c
+++ b/utils/src/util.c
@@ -145,7 +145,7 @@ int read_block_verify(int fd, u32 magic, u64 fsid, u64 blkno, int shift, void **
 		else if (fsid != 0 && le64_to_cpu(hdr->fsid) != fsid)
 			fprintf(stderr, "read blkno %llu has bad fsid %016llx != expected %016llx\n",
 				blkno, le64_to_cpu(hdr->fsid), fsid);
-		else if (le32_to_cpu(hdr->blkno) != blkno)
+		else if (le64_to_cpu(hdr->blkno) != blkno)
 			fprintf(stderr, "read blkno %llu has bad blkno %llu != expected %llu\n",
 				blkno, le64_to_cpu(hdr->blkno), blkno);
 		else

--- a/utils/src/util.h
+++ b/utils/src/util.h
@@ -81,6 +81,7 @@ do {				\
 							\
 	(_x == 0 ? 0 : 64 - __builtin_clzll(_x));	\
 })
+#define fls64(x) flsll(x)
 
 #define ilog2(x)					\
 ({							\

--- a/utils/src/util.h
+++ b/utils/src/util.h
@@ -2,6 +2,7 @@
 #define _UTIL_H_
 
 #include <unistd.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>

--- a/utils/src/util.h
+++ b/utils/src/util.h
@@ -99,6 +99,16 @@ emit_get_unaligned_le(16)
 emit_get_unaligned_le(32)
 emit_get_unaligned_le(64)
 
+#define emit_put_unaligned_le(nr)				\
+static inline void put_unaligned_le##nr(u##nr val, void *buf)	\
+{								\
+	__le##nr x = cpu_to_le##nr(val);			\
+	memcpy(buf, &x, sizeof(x));				\
+}
+emit_put_unaligned_le(16)
+emit_put_unaligned_le(32)
+emit_put_unaligned_le(64)
+
 /*
  * return -1,0,+1 based on the memcmp comparison of the minimum of their
  * two lengths.  If their min shared bytes are equal but the lengths

--- a/utils/src/util.h
+++ b/utils/src/util.h
@@ -69,6 +69,8 @@ do {				\
 #define container_of(ptr, type, memb) \
 	((type *)((void *)(ptr) - offsetof(type, memb)))
 
+#define NSEC_PER_SEC 1000000000
+
 #define BITS_PER_LONG (sizeof(long) * 8)
 #define U8_MAX ((u8)~0ULL)
 #define U16_MAX ((u16)~0ULL)


### PR DESCRIPTION
    Make sure that we have enough free blocks for the log trees to
    be merged once we finish mounting the system