### PR TITLE
Clean up large test files

### DIFF
--- a/tests/golden/basic-posix-consistency
+++ b/tests/golden/basic-posix-consistency
@@ -56,3 +56,4 @@ mv: cannot move '/mnt/test/test/basic-posix-consistency/dir/c/clobber' to '/mnt/
 == inode indexes match after removing and syncing
 == concurrent creates make one file
 one-file
+== cleanup

--- a/tests/golden/change-devices
+++ b/tests/golden/change-devices
@@ -25,3 +25,4 @@ rc: 0
 equal_prepared
 large_prepared
 resized larger test rc: 0
+== cleanup

--- a/tests/golden/quota
+++ b/tests/golden/quota
@@ -38,3 +38,4 @@ dd: error writing '/mnt/test/test/quota/dir/file': Disk quota exceeded
 fallocate: fallocate failed: Disk quota exceeded
 == added rules work after bulk restore
 touch: cannot touch '/mnt/test/test/quota/dir/file': Disk quota exceeded
+== cleanup

--- a/tests/golden/stage-release-race-alloc
+++ b/tests/golden/stage-release-race-alloc
@@ -1,2 +1,3 @@
 == create initial files
 == race stage and release
+== cleanup

--- a/tests/tests/basic-posix-consistency.sh
+++ b/tests/tests/basic-posix-consistency.sh
@@ -210,4 +210,7 @@ done
 wait
 ls "$T_D0/concurrent"
 
+echo "== cleanup"
+rm -f "$T_TMP.0" "$T_TMP.1"
+
 t_pass

--- a/tests/tests/change-devices.sh
+++ b/tests/tests/change-devices.sh
@@ -73,4 +73,7 @@ test "$large_tot" -gt "$equal_tot" ; echo "resized larger test rc: $?"
 umount "$SCR"
 losetup -d "$scr_loop"
 
+echo "== cleanup"
+rm -f "$T_TMP.small" "$T_TMP.equal" "$T_TMP.large"
+
 t_pass

--- a/tests/tests/quota.sh
+++ b/tests/tests/quota.sh
@@ -147,4 +147,7 @@ sync_and_drop
 setpriv $SET_UID touch "$FILE" 2>&1 | t_filter_fs
 reset_all
 
+echo "== cleanup"
+rm -f "$T_TMP.lots" "$T_TMP.list"
+
 t_pass

--- a/tests/tests/stage-release-race-alloc.sh
+++ b/tests/tests/stage-release-race-alloc.sh
@@ -62,4 +62,7 @@ for r in $(seq 1 1000); do
 	done
 done
 
+echo "== cleanup"
+rm -f "$T_TMP.log"
+
 t_pass


### PR DESCRIPTION
The test harness provides a TMP directory for tests to use.  It's badly named.  It's meant to be more of a scratch directory that is not on the FS being tested.

Tests use it both for small log files that give insight into the platform and for large generated files that are not worth saving.  We want to save the directory after test runs to get at the log files, but we don't want to burn a ton of space also saving large generated files

This updates the handful of tests to remove their handful of files that are large enough to be a problem.  With these out of the way we can save the tmp/ directory without its space consumption getting out of hand.