### PR TITLE
Write to kmsg which test we're executing.

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -557,6 +557,9 @@ for t in $tests; do
 
 	printf "  %-30s $stats" "$test_name"
 
+	# mark in dmesg as to what test we are running
+	echo "run scoutfs test $test_name" > /dev/kmsg
+
 	# record dmesg before
 	dmesg | t_filter_dmesg > "$T_TMPDIR/dmesg.before"
 


### PR DESCRIPTION
This is done by xfstests and it's so much easier to follow what is going on from logs or e.g. serial console that I thought I should do this for scoutfs tests as well. It makes it so much easier to discern which test may have been cause for issues when running a bunch of tests and you're looking back at logs later.

Example output:
```
[ 1505.441333] run scoutfs test basic-block-counts
[ 1506.344674] run scoutfs test basic-bad-mounts
[ 1506.420492] scoutfs f.000000.r.a0a21e error: meta_super META flag not set
[ 1506.427308] scoutfs f.000000.r.72434a error: could not open metadev: error -16
[ 1506.435016] scoutfs f.000000.r.ce1090 error: could not open metadev: error -16
[ 1506.441437] scoutfs f.000000.r.c280d6 error: Unknown or malformed option, "_bad"
[ 1506.543794] run scoutfs test inode-items-updated
[ 1507.375673] scoutfs f.aee145.r.47dede: client disconnected 127.0.0.1:41748 -> 127.0.0.1:42000
[ 1507.375688] scoutfs f.aee145.r.c673e4: client disconnected 127.0.0.1:41736 -> 127.0.0.1:42000
[ 1507.377121] scoutfs f.aee145.r.1211b4: server closing 127.0.0.1:42000 -> 127.0.0.1:41748
[ 1507.377977] scoutfs f.aee145.r.1211b4: server closing 127.0.0.1:42000 -> 127.0.0.1:41736
```