### PR TITLE
Don't pass data version to attr_x unless the ioctl means to set it.

### DIFF
--- a/kmod/src/ioctl.c
+++ b/kmod/src/ioctl.c
@@ -674,8 +674,8 @@ static long scoutfs_ioc_setattr_more(struct file *file, unsigned long arg)
 		goto out;
 	}
 
-	iax->x_mask = SCOUTFS_IOC_IAX_DATA_VERSION | SCOUTFS_IOC_IAX_CTIME |
-		      SCOUTFS_IOC_IAX_CRTIME | SCOUTFS_IOC_IAX_SIZE;
+	iax->x_mask = SCOUTFS_IOC_IAX_CTIME | SCOUTFS_IOC_IAX_CRTIME |
+		      SCOUTFS_IOC_IAX_SIZE;
 	iax->data_version = sm.data_version;
 	iax->ctime_sec = sm.ctime_sec;
 	iax->ctime_nsec = sm.ctime_nsec;
@@ -685,6 +685,9 @@ static long scoutfs_ioc_setattr_more(struct file *file, unsigned long arg)
 
 	if (sm.flags & SCOUTFS_IOC_SETATTR_MORE_OFFLINE)
 		iax->x_flags |= SCOUTFS_IOC_IAX_F_SIZE_OFFLINE;
+
+	if (sm.data_version != 0)
+		iax->x_mask |= SCOUTFS_IOC_IAX_DATA_VERSION;
 
 	ret = mnt_want_write_file(file);
 	if (ret < 0)

--- a/tests/golden/setattr_more
+++ b/tests/golden/setattr_more
@@ -29,3 +29,4 @@ File size of /mnt/test/test/setattr_more/file is 40988672 (10007 blocks of 4096 
 /mnt/test/test/setattr_more/file: 1 extent found
 == correct offline extent length
 976563
+== omitting data_version should not fail

--- a/tests/tests/setattr_more.sh
+++ b/tests/tests/setattr_more.sh
@@ -75,4 +75,11 @@ scoutfs setattr -V 1 -o -s 4000000000 "$FILE" 2>&1 | t_filter_fs
 scoutfs stat -s offline_blocks "$FILE"
 rm "$FILE"
 
+# Do not fail if data_version is unset - the unset `0` value should not
+# be passed down to attr_x handling code which will -EINVAL on that.
+echo "== omitting data_version should not fail"
+touch "$FILE"
+scoutfs setattr -s 0 -t 1725670311.0 -r 1725670311.0 "$FILE"
+rm "$FILE"
+
 t_pass


### PR DESCRIPTION
A small bug in the translation code from setattr_more to attr_x caused setattr to fail if a size zero was passed but no data version was passed.

Add a small test case for this. Without the fix this will produce the following error output ,and nothing with the fix:

  == i_size zero should not require data version to be set
  setattr_more ioctl failed on '/mnt/test.0/test/setattr_more/file': Invalid argument (22)
  scoutfs: setattr failed: Invalid argument (22)