### PR TITLE
Parallel_restore format v2 support

### DIFF
--- a/tests/golden/parallel_restore
+++ b/tests/golden/parallel_restore
@@ -16,8 +16,10 @@ total_data_blocks 15728640
  ext:     logical_offset:        physical_offset: length:   expected: flags:
    0:        0..       0:          0..         0:      1:             last,unknown_loc,eof
     Type  Size     Total   Used      Free  Use%  
-MetaData  64KB    163840  34721    129119    21  
+MetaData  64KB    163840  34722    129118    21
     Data   4KB  15728640     64  15728576     0  
+== print test quota rule
+  7 13,L,- 15,L,- 17,L,- I 33 -
 == unmount small meta fs
 == just under ENOSPC
     Type  Size     Total    Used      Free  Use%

--- a/tests/golden/parallel_restore
+++ b/tests/golden/parallel_restore
@@ -25,4 +25,8 @@ MetaData  64KB    163840  163840         0   100
     Data   4KB  15728640      64  15728576     0
 == just over ENOSPC
 == ENOSPC
+== attempt to restore data device
+== parallel_restore data device
+== attempt format_v1 restore
+== parallel_restore format_v1 fs
 == cleanup

--- a/tests/golden/parallel_restore
+++ b/tests/golden/parallel_restore
@@ -29,4 +29,7 @@ MetaData  64KB    163840  163840         0   100
 == parallel_restore data device
 == attempt format_v1 restore
 == parallel_restore format_v1 fs
+== test if previously mounted
+== mount before restore
+== parallel_restore previously mounted device
 == cleanup

--- a/tests/src/parallel_restore.c
+++ b/tests/src/parallel_restore.c
@@ -601,7 +601,7 @@ static int do_restore(struct opts *opts)
 	ret = scoutfs_parallel_restore_create_writer(&wri);
 	error_exit(ret, "create writer %d", ret);
 
-	ret = scoutfs_parallel_restore_import_super(wri, super);
+	ret = scoutfs_parallel_restore_import_super(wri, super, dev_fd);
 	error_exit(ret, "import super %d", ret);
 
 	slices = calloc(1 + opts->nr_writers, sizeof(struct scoutfs_parallel_restore_slice));

--- a/tests/src/restore_copy.c
+++ b/tests/src/restore_copy.c
@@ -672,7 +672,7 @@ static int do_restore(struct opts *opts)
 	ret = scoutfs_parallel_restore_create_writer(&wri);
 	error_exit(ret, "create writer %d", ret);
 
-	ret = scoutfs_parallel_restore_import_super(wri, super);
+	ret = scoutfs_parallel_restore_import_super(wri, super, dev_fd);
 	error_exit(ret, "import super %d", ret);
 
 	slices = calloc(2, sizeof(struct scoutfs_parallel_restore_slice));

--- a/tests/tests/parallel_restore.sh
+++ b/tests/tests/parallel_restore.sh
@@ -10,7 +10,7 @@ mkdir -p "$SCR"
 # XXX this is all pretty manual, would be nice to have helpers
 echo "== make small meta fs"
 # meta device just big enough for reserves and the metadata we'll fill
-scoutfs mkfs -A -f -Q 0,127.0.0.1,53000 -m 10G -d 60G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
+scoutfs mkfs -V 2 -A -f -Q 0,127.0.0.1,53000 -m 10G -d 60G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
 	t_fail "mkfs failed"
 mount -t scoutfs -o metadev_path=$T_EX_META_DEV,quorum_slot_nr=0 \
 	"$T_EX_DATA_DEV" "$SCR"
@@ -60,6 +60,20 @@ echo "== ENOSPC"
 scoutfs mkfs -A -f -Q 0,127.0.0.1,53000 -m 10G -d 60G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
 	t_fail "mkfs failed"
 parallel_restore -m "$T_EX_META_DEV" -d 600:1000 -f 600:1000 -n 4000000 | grep died 2>&1 && t_fail "parallel_restore"
+
+echo "== attempt to restore data device"
+scoutfs mkfs -V 2 -A -f -Q 0,127.0.0.1,53000 -m 10G -d 60G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
+	t_fail "mkfs failed"
+
+echo "== parallel_restore data device"
+parallel_restore -m "$T_EX_DATA_DEV" | grep died 2>&1 && t_fail "parallel_restore"
+
+echo "== attempt format_v1 restore"
+scoutfs mkfs -V 1 -A -f -Q 0,127.0.0.1,53000 -m 10G -d 60G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
+	t_fail "mkfs failed"
+
+echo "== parallel_restore format_v1 fs"
+parallel_restore -m "$T_EX_META_DEV" | grep died 2>&1 && t_fail "parallel_restore"
 
 echo "== cleanup"
 rmdir "$SCR"

--- a/tests/tests/parallel_restore.sh
+++ b/tests/tests/parallel_restore.sh
@@ -33,6 +33,9 @@ scoutfs search-xattrs -p "$SCR" scoutfs.hide.srch.sam_vol_F01030L6 -p "$SCR" | w
 find "$SCR" -type f -name "file-*" | head -n 4 | xargs -n 1 filefrag-gc57857a5 -b4096 -v | grep -e ext: -e eof
 scoutfs df -p "$SCR"
 
+echo "== print test quota rule"
+scoutfs quota-list -p "$SCR"
+
 echo "== unmount small meta fs"
 umount "$SCR"
 

--- a/tests/tests/parallel_restore.sh
+++ b/tests/tests/parallel_restore.sh
@@ -75,6 +75,18 @@ scoutfs mkfs -V 1 -A -f -Q 0,127.0.0.1,53000 -m 10G -d 60G "$T_EX_META_DEV" "$T_
 echo "== parallel_restore format_v1 fs"
 parallel_restore -m "$T_EX_META_DEV" | grep died 2>&1 && t_fail "parallel_restore"
 
+echo "== test if previously mounted"
+scoutfs mkfs -V 2 -A -f -Q 0,127.0.0.1,53000 -m 10G -d 60G "$T_EX_META_DEV" "$T_EX_DATA_DEV" > $T_TMP.mkfs.out 2>&1 || \
+	t_fail "mkfs failed"
+
+echo "== mount before restore"
+mount -t scoutfs -o metadev_path=$T_EX_META_DEV,quorum_slot_nr=0 \
+	"$T_EX_DATA_DEV" "$SCR"
+umount "$SCR"
+
+echo "== parallel_restore previously mounted device"
+parallel_restore -m "$T_EX_META_DEV" | grep died 2>&1 && t_fail "parallel_restore"
+
 echo "== cleanup"
 rmdir "$SCR"
 t_pass

--- a/utils/src/parallel_restore.c
+++ b/utils/src/parallel_restore.c
@@ -818,6 +818,7 @@ static spr_err_t insert_inode_items(struct scoutfs_parallel_restore_writer *wri,
 	si->mode = cpu_to_le32(inode->mode);
 	si->rdev = cpu_to_le32(inode->rdev);
 	si->flags = 0;
+	si->flags = cpu_to_le64(inode->flags);
 	si->atime.sec = cpu_to_le64(inode->atime.tv_sec);
 	si->atime.nsec = cpu_to_le32(inode->atime.tv_nsec);
 	si->ctime.sec = cpu_to_le64(inode->ctime.tv_sec);

--- a/utils/src/parallel_restore.c
+++ b/utils/src/parallel_restore.c
@@ -1839,6 +1839,12 @@ spr_err_t scoutfs_parallel_restore_import_super(struct scoutfs_parallel_restore_
 	u64 start;
 	u64 len;
 
+	if (le64_to_cpu(super->fmt_vers) < 2)
+		return EINVAL;
+
+	if ((super->flags & SCOUTFS_FLAG_IS_META_BDEV) == 0)
+		return EINVAL;
+
 	if (wri_has_super(wri))
 		return EINVAL;
 

--- a/utils/src/parallel_restore.c
+++ b/utils/src/parallel_restore.c
@@ -826,6 +826,7 @@ static spr_err_t insert_inode_items(struct scoutfs_parallel_restore_writer *wri,
 	si->mtime.nsec = cpu_to_le32(inode->mtime.tv_nsec);
 	si->crtime.sec = cpu_to_le64(inode->crtime.tv_sec);
 	si->crtime.nsec = cpu_to_le32(inode->crtime.tv_nsec);
+	si->proj = cpu_to_le64(inode->proj);
 
 	err = insert_inode_index_item(wri, SCOUTFS_INODE_INDEX_META_SEQ_TYPE,
 				      le64_to_cpu(si->meta_seq), inode->ino);

--- a/utils/src/parallel_restore.c
+++ b/utils/src/parallel_restore.c
@@ -405,7 +405,8 @@ static spr_err_t map_start_key(struct scoutfs_key *start, struct scoutfs_key *ke
 		init_key(start, SCOUTFS_INODE_INDEX_ZONE, 0, 0,
 			 le64_to_cpu(key->_sk_second) & ~(u64)SCOUTFS_LOCK_SEQ_GROUP_MASK,
 			 0, 0);
-
+	} else if (key->sk_zone == SCOUTFS_QUOTA_ZONE) {
+		init_key(start, SCOUTFS_QUOTA_ZONE, 0, 0, le64_to_cpu(key->_sk_second), 0, 0);
 	} else {
 		return EINVAL;
 	}
@@ -917,6 +918,46 @@ static spr_err_t insert_srch_item(struct scoutfs_parallel_restore_writer *wri,
 		err = btb_insert(&wri->srch_btb, bti, 0);
 	}
 
+	return err;
+}
+
+static spr_err_t insert_quota_item(struct scoutfs_parallel_restore_writer *wri,
+				  struct scoutfs_parallel_restore_quota_rule *rule)
+{
+	struct scoutfs_quota_rule_val *rv;
+	struct btree_item *bti;
+	spr_err_t err;
+
+	err = bti_alloc(sizeof(struct scoutfs_quota_rule_val), &bti);
+	if (err)
+		goto out;
+
+	rv = bti->val;
+	memset(rv, 0, sizeof(struct scoutfs_quota_rule_val));
+	rv->limit = cpu_to_le64(rule->limit);
+	rv->prio = rule->prio;
+	rv->op = rule->op;
+	rv->rule_flags = rule->rule_flags;
+	rv->name_val[0] = cpu_to_le64(rule->names[0].val);
+	rv->name_source[0] = rule->names[0].source;
+	rv->name_flags[0] = rule->names[0].flags;
+	rv->name_val[1] = cpu_to_le64(rule->names[1].val);
+	rv->name_source[1] = rule->names[1].source;
+	rv->name_flags[1] = rule->names[1].flags;
+	rv->name_val[2] = cpu_to_le64(rule->names[2].val);
+	rv->name_source[2] = rule->names[2].source;
+	rv->name_flags[2] = rule->names[2].flags;
+	memset(&rv->_pad, 0, sizeof(rv->_pad));
+
+	init_key(&bti->key, SCOUTFS_QUOTA_ZONE, SCOUTFS_QUOTA_RULE_TYPE,
+			0, scoutfs_hash64(&rv, sizeof(rv)), 0, 0);
+
+	err = insert_fs_item(wri, bti);
+	if (err) {
+		free(bti);
+		goto out;
+	}
+out:
 	return err;
 }
 
@@ -1779,6 +1820,15 @@ spr_err_t scoutfs_parallel_restore_add_progress(struct scoutfs_parallel_restore_
 	      err = insert_srch_item(wri, &prog->sfl);
 
 	return err;
+}
+
+spr_err_t scoutfs_parallel_restore_add_quota_rule(struct scoutfs_parallel_restore_writer *wri,
+						struct scoutfs_parallel_restore_quota_rule *rule)
+{
+	if (!wri_has_super(wri))
+		return EINVAL;
+
+	return insert_quota_item(wri, rule);
 }
 
 spr_err_t scoutfs_parallel_restore_write_buf(struct scoutfs_parallel_restore_writer *wri,

--- a/utils/src/parallel_restore.h
+++ b/utils/src/parallel_restore.h
@@ -68,6 +68,20 @@ struct scoutfs_parallel_restore_inode {
 	unsigned int target_len; /* not including null terminator */
 };
 
+struct scoutfs_parallel_restore_quota_rule {
+	u64 limit;
+	u8  prio;
+	u8  op;
+	u8  rule_flags;
+	struct quota_rule_name {
+		u64 val;
+		u8  source;
+		u8  flags;
+	} names [3];
+	char *value;
+	unsigned int value_len;
+};
+
 typedef __typeof__(EINVAL) spr_err_t;
 
 struct scoutfs_parallel_restore_writer;
@@ -94,6 +108,9 @@ spr_err_t scoutfs_parallel_restore_get_progress(struct scoutfs_parallel_restore_
 						struct scoutfs_parallel_restore_progress *prog);
 spr_err_t scoutfs_parallel_restore_add_progress(struct scoutfs_parallel_restore_writer *wri,
 						struct scoutfs_parallel_restore_progress *prog);
+
+spr_err_t scoutfs_parallel_restore_add_quota_rule(struct scoutfs_parallel_restore_writer *wri,
+						struct scoutfs_parallel_restore_quota_rule *rule);
 
 spr_err_t scoutfs_parallel_restore_write_buf(struct scoutfs_parallel_restore_writer *wri,
 					     void *buf, size_t len, off_t *off_ret,

--- a/utils/src/parallel_restore.h
+++ b/utils/src/parallel_restore.h
@@ -46,6 +46,8 @@ struct scoutfs_parallel_restore_inode {
 	u32 gid;
 	u32 mode;
 	u32 rdev;
+	u32 flags;
+	u8 pad[4];
 	struct timespec atime;
 	struct timespec ctime;
 	struct timespec mtime;

--- a/utils/src/parallel_restore.h
+++ b/utils/src/parallel_restore.h
@@ -50,6 +50,7 @@ struct scoutfs_parallel_restore_inode {
 	struct timespec ctime;
 	struct timespec mtime;
 	struct timespec crtime;
+	u64 proj;
 
 	/* regular files */
 	u64 data_version;

--- a/utils/src/parallel_restore.h
+++ b/utils/src/parallel_restore.h
@@ -97,7 +97,7 @@ spr_err_t scoutfs_parallel_restore_write_buf(struct scoutfs_parallel_restore_wri
 					     size_t *count_ret);
 
 spr_err_t scoutfs_parallel_restore_import_super(struct scoutfs_parallel_restore_writer *wri,
-						struct scoutfs_super_block *super);
+						struct scoutfs_super_block *super, int fd);
 spr_err_t scoutfs_parallel_restore_export_super(struct scoutfs_parallel_restore_writer *wri,
 						struct scoutfs_super_block *super);
 


### PR DESCRIPTION
Add support for new format v2 structures. In this branch only scoutfs filesystem format v2 will be supported