### PR TITLE
Add shrinker counters for wkic and quota_info.

### DIFF
--- a/kmod/src/counters.h
+++ b/kmod/src/counters.h
@@ -162,6 +162,8 @@
 	EXPAND_COUNTER(orphan_scan_error)			\
 	EXPAND_COUNTER(orphan_scan_item)			\
 	EXPAND_COUNTER(orphan_scan_omap_set)			\
+	EXPAND_COUNTER(quota_info_count_objects)		\
+	EXPAND_COUNTER(quota_info_scan_objects)			\
 	EXPAND_COUNTER(quorum_candidate_server_stopping)	\
 	EXPAND_COUNTER(quorum_elected)				\
 	EXPAND_COUNTER(quorum_fence_error)			\
@@ -206,10 +208,12 @@
 	EXPAND_COUNTER(trans_commit_meta_alloc_low)		\
 	EXPAND_COUNTER(trans_commit_sync_fs)			\
 	EXPAND_COUNTER(trans_commit_timer)			\
-	EXPAND_COUNTER(trans_commit_written)
+	EXPAND_COUNTER(trans_commit_written)			\
+	EXPAND_COUNTER(wkic_count_objects)			\
+	EXPAND_COUNTER(wkic_scan_objects)
 
 #define FIRST_COUNTER	alloc_alloc_data
-#define LAST_COUNTER	trans_commit_written
+#define LAST_COUNTER	wkic_scan_objects
 
 #undef EXPAND_COUNTER
 #define EXPAND_COUNTER(which) struct percpu_counter which;

--- a/kmod/src/quota.c
+++ b/kmod/src/quota.c
@@ -34,6 +34,7 @@
 #include "totl.h"
 #include "util.h"
 #include "quota.h"
+#include "counters.h"
 #include "scoutfs_trace.h"
 
 /*
@@ -219,6 +220,8 @@ static unsigned long count_cached_checks(struct shrinker *shrink, struct shrink_
 {
 	struct squota_info *qtinf = KC_SHRINKER_CONTAINER_OF(shrink, struct squota_info);
 
+	scoutfs_inc_counter(qtinf->sb, quota_info_count_objects);
+
 	return shrinker_min_long(atomic64_read(&qtinf->nr_checks));
 }
 
@@ -236,6 +239,8 @@ static unsigned long scan_cached_checks(struct shrinker *shrink, struct shrink_c
 	unsigned long freed = 0;
 	struct squota_check *chk;
 	int err;
+
+	scoutfs_inc_counter(qtinf->sb, quota_info_scan_objects);
 
 	rcu_read_lock();
 

--- a/kmod/src/wkic.c
+++ b/kmod/src/wkic.c
@@ -27,6 +27,7 @@
 #include "totl.h"
 #include "counters.h"
 #include "util.h"
+#include "counters.h"
 #include "scoutfs_trace.h"
 #include "wkic.h"
 
@@ -552,6 +553,8 @@ static unsigned long wkic_shrink_count(struct shrinker *shrink, struct shrink_co
 {
 	struct wkic_info *winf = KC_SHRINKER_CONTAINER_OF(shrink, struct wkic_info);
 
+	scoutfs_inc_counter(winf->sb, wkic_count_objects);
+
 	return shrinker_min_long(atomic64_read(&winf->shrink_count));
 }
 
@@ -563,6 +566,8 @@ static unsigned long wkic_shrink_scan(struct shrinker *shrink, struct shrink_con
 	unsigned long before;
 	unsigned long after;
 	LIST_HEAD(empty_list);
+
+	scoutfs_inc_counter(winf->sb, wkic_scan_objects);
 
 	if (sc->nr_to_scan > 0) {
 		before = wkic_shrink_count(shrink, sc);


### PR DESCRIPTION
These new shrinkers were recently added. Because there's very little ways to debug them, or even see them properly function, we should at least add counters for them.