### PR TITLE
Allow skipping of tests.

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -644,16 +644,16 @@ if [ -n "$T_TRACE_GLOB" -o -n "$T_TRACE_PRINTK" ]; then
 	fi
 fi
 
-if [ "$skipped" == 0 -a "$failed" == 0 ]; then
-	msg "all tests passed"
+if [ "$skipped" != 0 ]; then
+	msg "$skipped tests skipped, check skip.log"
+fi
+
+if [ "$failed" == 0 ]; then
+	msg "no tests failed"
 	unmount_all
 	exit 0
 fi
 
-if [ "$skipped" != 0 ]; then
-	msg "$skipped tests skipped, check skip.log, still mounted"
-fi
-if [ "$failed" != 0 ]; then
-	msg "$failed tests failed, check fail.log, still mounted"
-fi
+msg "$failed tests failed, check fail.log, still mounted"
+
 exit 1


### PR DESCRIPTION
With el9, we will be skipping the format-version-forward-back test on el9 platforms, because the test requires that we compile and run code that has no el9 support. For that test, we will rely on older OS versions to not fail, and it will not be skipped there.

So we have to modify our outcome checks otherwise all el9 builds will fail testing no matter what. This is the simplest form where tests can skip - only failing tests will return an error code.