### PR TITLE
Don't fence clients with rid==0

### DIFF
--- a/kmod/src/fence.c
+++ b/kmod/src/fence.c
@@ -238,6 +238,11 @@ int scoutfs_fence_start(struct super_block *sb, u64 rid, __be32 ipv4_addr, int r
 	struct pending_fence *fence;
 	int ret;
 
+	if (!rid) {
+		ret = 0;
+		goto out;
+	}
+
 	fence = kzalloc(sizeof(struct pending_fence), GFP_NOFS);
 	if (!fence) {
 		ret = -ENOMEM;


### PR DESCRIPTION
Occasionally during the export-lookup-evict-race test we see the following failure dmesg output when a server fences a client that has no valid rid:

[  828.379546] sysfs: cannot create duplicate filename '/fs/scoutfs/f.b928e1.r.7b36c0/fence/0000000000000000' ...
[  828.379773] kobject_add_internal failed for 0000000000000000 with -EEXIST, don't try to register things with the same name in the same directory. [  828.385946] scoutfs f.b928e1.r.7b36c0 error: client fence returned err -17, shutting down server

This fails the test. Fencing these clients is unwanted, but we definitely don't want to create duplicate sysfs entries for it, either.

Don't fence clients like this, just return 0.