### PR TITLE
Make `df` print out blocks free based on data, only

### DIFF
--- a/kmod/src/super.c
+++ b/kmod/src/super.c
@@ -102,12 +102,10 @@ static int scoutfs_statfs(struct dentry *dentry, struct kstatfs *kst)
 	if (ret)
 		goto out;
 
-	kst->f_bfree = (le64_to_cpu(nst.free_meta_blocks) << SCOUTFS_BLOCK_SM_LG_SHIFT) +
-		       le64_to_cpu(nst.free_data_blocks);
+	kst->f_bfree = le64_to_cpu(nst.free_data_blocks);
 	kst->f_type = SCOUTFS_SUPER_MAGIC;
 	kst->f_bsize = SCOUTFS_BLOCK_SM_SIZE;
-	kst->f_blocks = (le64_to_cpu(nst.total_meta_blocks) << SCOUTFS_BLOCK_SM_LG_SHIFT) +
-			le64_to_cpu(nst.total_data_blocks);
+	kst->f_blocks = le64_to_cpu(nst.total_data_blocks);
 	kst->f_bavail = kst->f_bfree;
 
 	files = div_u64(le64_to_cpu(nst.total_meta_blocks) << SCOUTFS_BLOCK_LG_SHIFT, 2048);


### PR DESCRIPTION
The current `df` output displays an estimate of free disk space available based on the usage of both meta and data device.

Change it to purely report back on data device usage only.

There are arguments both for and against this. First, it is an obvious change in current behavior, that may break existing scripts and usage reporting methods.

Arguments for this are that this is easier to understand for users - the number will now reflect whether more data can be stored, or whether data needs to be released or not to meet availability requirements.