### PR TITLE
Block EL9 minor version upgrades

### DIFF
--- a/kmod/scoutfs-kmod.spec.in
+++ b/kmod/scoutfs-kmod.spec.in
@@ -53,6 +53,18 @@ Source:		%{kmod_name}-kmod-%{kmod_version}.tar
 %global flavors_to_build x86_64
 %endif
 
+# el9 sanity: make sure we lock to the minor release we built for and block upgrades
+%{lua:
+  if string.match(rpm.expand("%{dist}"), "%.el9") then
+    rpm.define("el9 1")
+  end
+}
+
+%if 0%{?el9}
+%define release_major_minor 9.%{lua: print(rpm.expand("%{dist}"):match("%.el9_(%d)"))}
+Requires: system-release = %{release_major_minor}
+%endif
+
 %description
 %{kmod_name} - kernel module
 


### PR DESCRIPTION
Since kABI migrations across minor versions is a thing of the past going
forward, we now:
- Detect if we're on EL9
- If so, add a requirement on the various flavors of release package to
  that specific major.minor version

This appropriately does not allow upgrades across minor versions.