### PR TITLE
Swap meta allocators with much more reserve.

### DIFF
--- a/kmod/src/server.c
+++ b/kmod/src/server.c
@@ -668,14 +668,16 @@ static void scoutfs_server_commit_func(struct work_struct *work)
 	 * the reserved blocks after having filled the log trees's avail
 	 * allocator during its transaction.  To avoid prematurely
 	 * setting the low flag and causing enospc we make sure that the
-	 * next transaction's meta_avail has 2x the reserved blocks so
+	 * next transaction's meta_avail has 3x the reserved blocks so
 	 * that it can consume a full reserved amount and still have
 	 * enough to avoid enospc.  We swap to freed if avail is under
-	 * the buffer and freed is larger.
+	 * the buffer and freed is larger by 50%. This results in much less
+	 * swapping overall and allows the pools to refill naturally.
 	 */
 	if ((le64_to_cpu(server->meta_avail->total_len) <
-	     (scoutfs_server_reserved_meta_blocks(sb) * 2)) &&
-	    (le64_to_cpu(server->meta_freed->total_len) >
+	     (scoutfs_server_reserved_meta_blocks(sb) * 3)) &&
+	    ((le64_to_cpu(server->meta_freed->total_len) +
+	     (le64_to_cpu(server->meta_freed->total_len) >> 1)) >
 	     le64_to_cpu(server->meta_avail->total_len)))
 		swap(server->meta_avail, server->meta_freed);
 


### PR DESCRIPTION
This is the core of the meta allocator swapping change: swap a little bit earlier, but always swap only when _freed is much larger than _avail. 

From my observations I can see that without this change, both allocators bleed slowly to empty without either of them regaining enough over time to continue work. In effect, we never recover from ENOSPC. Everything grinds to a halt, the allocators just swap endlessly and transactions take forever to complete.

With this change we avoid all that - we purposely let our _avail allocator go much lower than _freed before we swap. This assures that whenever we swap we let enough blocks recycle post transactions into _freed so that it gets us out of ENOSPC again, and into a healthy state again.

I think.