### PR TITLE
Fix new_inode ctime assignment.

### DIFF
--- a/kmod/src/dir.c
+++ b/kmod/src/dir.c
@@ -1765,7 +1765,7 @@ retry:
 	}
 	old_inode->i_ctime = now;
 	if (new_inode)
-		old_inode->i_ctime = now;
+		new_inode->i_ctime = now;
 
 	inode_inc_iversion(old_dir);
 	inode_inc_iversion(old_inode);


### PR DESCRIPTION
Very old copy/paste bug here, we want to update new_inode's ctime instead. old_inode already is updated.