### PR TITLE
Remove wordexp expansion of utils path argument

### DIFF
--- a/utils/src/util.c
+++ b/utils/src/util.c
@@ -7,7 +7,6 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <wordexp.h>
 
 #include "util.h"
 #include "format.h"
@@ -18,25 +17,14 @@
 
 static int open_path(char *path, int flags)
 {
-	wordexp_t exp_result;
 	int ret;
 
-	ret = wordexp(path, &exp_result, WRDE_NOCMD | WRDE_SHOWERR | WRDE_UNDEF);
-	if (ret) {
-		fprintf(stderr, "wordexp() failure for \"%s\": %d\n", path, ret);
-		ret = -EINVAL;
-		goto out;
-	}
-
-	ret = open(exp_result.we_wordv[0], flags);
+	ret = open(path, flags);
 	if (ret < 0) {
 		ret = -errno;
 		fprintf(stderr, "failed to open '%s': %s (%d)\n",
 			path, strerror(errno), errno);
 	}
-
-out:
-	wordfree(&exp_result);
 
 	return ret;
 }


### PR DESCRIPTION
scoutfs cli commands were using a helper that tried to perform word expansion on the path argument.  This was done with the intent of providing the convenience of shell expansion (env vars, ~) within the cli command argument.

But it breaks paths that accidentally have their file names match the
syntax that wordexp supports.   "[ ]" tripped up files in the wild.

We don't need to provide shell expansion functionality in our argument parsing.  The shell can do that.  The cli must pass the arguments straight through, no parsing at all.