### PR TITLE
Ignore pipefail alternative error when not a tty.

### DIFF
--- a/tests/tests/basic-truncate.sh
+++ b/tests/tests/basic-truncate.sh
@@ -11,7 +11,7 @@ FILE="$T_D0/file"
 # final block as we truncated past it.
 #
 echo "== truncate writes zeroed partial end of file block"
-yes | dd of="$FILE" bs=8K count=1 status=none iflag=fullblock
+yes 2>/dev/null | dd of="$FILE" bs=8K count=1 status=none iflag=fullblock
 sync
 
 # not passing iflag=fullblock causes the file occasionally to just be


### PR DESCRIPTION
This happens with the basic-truncate test, only. It's the only user of the `yes` program.

The `yes` command normally fails gracefully under the usual runs that are attached to some terminal. But when the test script runs entirely under something else, it will throw a needless error message that pollutes the test output:

  `yes: standard output: Broken pipe`

Adjust the redirect to omit all stderr for `yes` in this case.