### PR TITLE
Introduce meta_reserve_blocks mount option, default value.

### DIFF
--- a/kmod/src/options.h
+++ b/kmod/src/options.h
@@ -13,6 +13,7 @@ struct scoutfs_mount_options {
 	unsigned int orphan_scan_delay_ms;
 	int quorum_slot_nr;
 	u64 quorum_heartbeat_timeout_ms;
+	u64 meta_reserve_blocks;
 };
 
 void scoutfs_options_read(struct super_block *sb, struct scoutfs_mount_options *opts);

--- a/kmod/src/server.c
+++ b/kmod/src/server.c
@@ -772,10 +772,13 @@ static int alloc_move_empty(struct super_block *sb,
 u64 scoutfs_server_reserved_meta_blocks(struct super_block *sb)
 {
 	DECLARE_SERVER_INFO(sb, server);
+	struct scoutfs_mount_options opts;
 	u64 server_blocks;
 	u64 client_blocks;
 	u64 log_blocks;
 	u64 nr_clients;
+
+	scoutfs_options_read(sb, &opts);
 
 	/* server has two meta_avail lists it swaps between */
 	server_blocks = SCOUTFS_SERVER_META_FILL_TARGET * 2;
@@ -801,7 +804,7 @@ u64 scoutfs_server_reserved_meta_blocks(struct super_block *sb)
 	nr_clients = server->nr_clients;
 	spin_unlock(&server->lock);
 
-	return server_blocks + (max(1ULL, nr_clients) * client_blocks);
+	return server_blocks + (max(1ULL, nr_clients) * client_blocks) + opts.meta_reserve_blocks;
 }
 
 /*

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -464,6 +464,7 @@ for i in $(seq 0 $((T_NR_MOUNTS - 1))); do
 	if [ "$i" -lt "$T_QUORUM" ]; then
 		opts="$opts,quorum_slot_nr=$i"
 	fi
+	opts="$opts,meta_reserve_blocks=0"
 	opts="${opts}${T_MNT_OPTIONS}"
 
 	msg "mounting $meta_dev|$data_dev on $dir"


### PR DESCRIPTION
This option adds a mount option, with default value of 16384, that adds an additional reserve amount of blocks for the meta device.

The default value is 16384, which corresponds to 1GB of space, and just about doubles the internal value for the reserve that is calculated based on clients/mounts dynamically in sort of standard values. It also just compromises about less than 2% of the meta device size for the smallest meta device size.

A suggested value for larger deployments is like somewhere around 256 blocks per GB of meta device size, i.e. 1/64 of the meta device space, and about 1.6% in effect.

Customers who are running into issues can adjust their mount options to increase the value to have a larger safety buffer, or decrease it to potentially have a way to get out of low space conditions temporarily. Obviously one would want to increase the value of this option after resolving the low space condition issues as soon as possible.

Our test suite will run with meta_reserve_blocks=0, so that the behavior of any of our tests is functionally unaffected by this change, and won't interfere with resolving underlying ENOSPC issues and their resolution. The addition of this option however allows us to artifically create ENOSPC conditions at will, and we may want to add tests specifically that do so.