### PR TITLE
prandom_bytes and family removed, switch to get_random_bytes variants.

### DIFF
--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -434,3 +434,11 @@ endif
 ifneq (,$(shell grep 'int ..remap_pages..struct vm_area_struct' include/linux/mm.h))
 ccflags-y += -DKC_MM_REMAP_PAGES
 endif
+
+#
+# v6.1-rc5-2-ge9a688bcb193
+#
+# get_random_u32_below() implementation
+ifneq (,$(shell grep -q 'u32 get_random_u32_below' include/linux/random.h))
+ccflags-y += -DKC_HAVE_GET_RANDOM_U32_BELOW
+endif

--- a/kmod/src/block.c
+++ b/kmod/src/block.c
@@ -900,7 +900,7 @@ int scoutfs_block_dirty_ref(struct super_block *sb, struct scoutfs_alloc *alloc,
 	hdr->magic = cpu_to_le32(magic);
 	hdr->fsid = cpu_to_le64(sbi->fsid);
 	hdr->blkno = cpu_to_le64(bl->blkno);
-	prandom_bytes(&hdr->seq, sizeof(hdr->seq));
+	get_random_bytes(&hdr->seq, sizeof(hdr->seq));
 
 	trace_scoutfs_block_dirty_ref(sb, le64_to_cpu(ref->blkno), le64_to_cpu(ref->seq),
 				      le64_to_cpu(hdr->blkno), le64_to_cpu(hdr->seq));
@@ -1129,7 +1129,7 @@ static unsigned long block_scan_objects(struct shrinker *shrink, struct shrink_c
 	 * _nexts per shrink.
 	 */
 	if (iter.walker.tbl)
-		iter.slot = prandom_u32_max(iter.walker.tbl->size);
+		iter.slot = get_random_u32_below(iter.walker.tbl->size);
 
 	while (nr > 0) {
 		bp = rhashtable_walk_next(&iter);

--- a/kmod/src/inode.c
+++ b/kmod/src/inode.c
@@ -2020,7 +2020,7 @@ void scoutfs_inode_schedule_orphan_dwork(struct super_block *sb)
 
 		low = (opts.orphan_scan_delay_ms * 80) / 100;
 		high = (opts.orphan_scan_delay_ms * 120) / 100;
-		delay = msecs_to_jiffies(low + prandom_u32_max(high - low)) ?: 1;
+		delay = msecs_to_jiffies(low + get_random_u32_below(high - low)) ?: 1;
 
 		mod_delayed_work(system_wq, &inf->orphan_scan_dwork, delay);
 	}

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -410,4 +410,8 @@ static inline vm_fault_t vmf_error(int err)
 }
 #endif
 
+#ifndef KC_HAVE_GET_RANDOM_U32_BELOW
+#define get_random_u32_below prandom_u32_max
+#endif
+
 #endif

--- a/kmod/src/quorum.c
+++ b/kmod/src/quorum.c
@@ -162,7 +162,7 @@ static void quorum_slot_sin(struct scoutfs_quorum_config *qconf, int i, struct s
 static ktime_t election_timeout(void)
 {
 	return ktime_add_ms(ktime_get(), SCOUTFS_QUORUM_ELECT_MIN_MS +
-				 prandom_u32_max(SCOUTFS_QUORUM_ELECT_VAR_MS));
+				 get_random_u32_below(SCOUTFS_QUORUM_ELECT_VAR_MS));
 }
 
 static ktime_t heartbeat_interval(void)

--- a/kmod/src/quota.c
+++ b/kmod/src/quota.c
@@ -204,7 +204,7 @@ static struct squota_check *lookup_random_check(struct rhashtable *rht)
 
 	tbl = rht_dereference_rcu(rht->tbl, rht);
 	do {
-		for (s = 0, i = prandom_u32_max(tbl->size);
+		for (s = 0, i = get_random_u32_below(tbl->size);
 		     s < tbl->size;
 		     s++, i = (i + 1) % tbl->size) {
 			rht_for_each_entry_rcu(chk, pos, tbl, i, head) {


### PR DESCRIPTION
In v6.1-rc5-2-ge9a688bcb193, get_random_u32_below() becomes available and can start replacing prandom_bytes_max(). Switch to it where we can.

get_random_bytes() has been available since el7, so also replace prandom_bytes() where we're using it.