### PR TITLE
Fix test cases that don't run cleanly in a semi-dirty env.

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -532,12 +532,15 @@ for t in $tests; do
 	cmd rm -rf "$T_TMPDIR"
 	cmd mkdir -p "$T_TMPDIR"
 
-	# create a test name dir in the fs
+	# create a test name dir in the fs, clean up old data as needed
 	T_DS=""
 	for i in $(seq 0 $((T_NR_MOUNTS - 1))); do
 		dir="${T_M[$i]}/test/$test_name"
 
-		test $i == 0 && cmd mkdir -p "$dir"
+		test $i == 0 && (
+			test -d "$dir" && cmd rm -rf "$dir"
+			cmd mkdir -p "$dir"
+		)
 
 		eval T_D$i=$dir
 		T_D[$i]=$dir


### PR DESCRIPTION
All these tests don't properly clean up themselves or assume a pristine empty folder when starting, and fall over their own generated test files when repeatedly run without e.g. `-m` (mkfs each time) option passed to the test harnass. And that has implications.

I'm not a fan of tests that fully `rm -rf` everything after a test run because that makes it cumbersome to play around and inspect the test files after a test run. The most minimal change we can make is just to assure that test cases that require some clean initial state is present, will have it. This change does just that.