### PR TITLE
Give enospc test more time to commit unlink.

### DIFF
--- a/tests/tests/enospc.sh
+++ b/tests/tests/enospc.sh
@@ -88,6 +88,11 @@ rm -rf "$SCR/xattrs"
 
 echo "== make sure we can create again"
 file="$SCR/file-after"
+C=120
+while (( C-- )); do
+	touch $file 2> /dev/null && break
+	sleep 1
+done
 touch $file
 setfattr -n user.scoutfs-enospc -v 1 "$file"
 sync


### PR DESCRIPTION
The current test sequence performs the unlink and immediately tests whether enough resources are available to create new files again, and this consistently fails.

One of my crummy VMs takes a good 12 seconds before the `touch` actually succeeds. We care about the filesystem eventually returning from ENOSPC, and certainly we don't want it to take forever, but there is a period after our first ENOSPC error and cleanup that we expect ENOSPC to fail for a bit longer.

Make the timeout 120s. As soon as the `touch` completes, exit the wait loop.