### PR TITLE
**WIP** Export PID through scoutfs_ioctl_data_waiting.

### DIFF
--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -1821,6 +1821,7 @@ int scoutfs_data_wait_check(struct inode *inode, loff_t pos, loff_t len,
 				dw->ino = ino;
 				dw->iblock = max(iblock, ext.start);
 				dw->op = op;
+				dw->pid = task_pid_nr(current);
 
 				spin_lock(&rt->lock);
 				insert_offline_waiting(&rt->root, dw);
@@ -1943,6 +1944,7 @@ int scoutfs_data_waiting(struct super_block *sb, u64 ino, u64 iblock,
 		dwe->ino = dw->ino;
 		dwe->iblock = dw->iblock;
 		dwe->op = dw->op;
+		dwe->pid = dw->pid;
 
 		while ((dw = dw_next(dw)) &&
 		       (dw->ino == dwe->ino && dw->iblock == dwe->iblock)) {

--- a/kmod/src/data.h
+++ b/kmod/src/data.h
@@ -29,6 +29,7 @@ struct scoutfs_data_wait {
 	u64 ino;
 	u64 iblock;
 	long err;
+	pid_t pid;
 	u8 op;
 };
 

--- a/kmod/src/ioctl.h
+++ b/kmod/src/ioctl.h
@@ -234,7 +234,8 @@ struct scoutfs_ioctl_data_waiting_entry {
 	__u64 ino;
 	__u64 iblock;
 	__u8 op;
-	__u8 _pad[7];
+	__u8 _pad[3]; /* hole for backwards compat */
+	__s32 pid; /* pid_t */
 };
 
 #define SCOUTFS_IOC_DWO_READ		(1 << 0)

--- a/tests/golden/offline-extent-waiting
+++ b/tests/golden/offline-extent-waiting
@@ -7,6 +7,9 @@ offline waiting should now have one known entry:
 offline waiting still has one known entry:
 == different blocks show up
 offline waiting now has two known entries:
+== verify PIDs match
+ pid <MATCHPID1> ops read
+ pid <MATCHPID2> ops read
 == staging wakes everyone
 offline waiting should be empty again:
 0

--- a/utils/src/waiting.c
+++ b/utils/src/waiting.c
@@ -72,9 +72,9 @@ static int do_waiting(struct waiting_args *args)
 		}
 
 		for (i = 0; i < ret; i++)
-			printf("ino %llu iblock %llu ops "
+			printf("ino %llu iblock %llu pid %i ops "
 			       OP_FMT OP_FMT OP_FMT"\n",
-			       dwe[i].ino, dwe[i].iblock,
+			       dwe[i].ino, dwe[i].iblock, dwe[i].pid,
 			       op_str(dwe[i].op, SCOUTFS_IOC_DWO_READ,
 				      "read"),
 			       op_str(dwe[i].op, SCOUTFS_IOC_DWO_WRITE,


### PR DESCRIPTION
Modify the return data from the data waiting ioctl so we can pass the pid of the process that is waiting for data to become online back to userspace. Userspace can then decide how to handle special cases like nfsd, which can make nfsd non-blocking on offline files.

The ioctl passes an array of struct that has 7 bytes padding that is currently unused. We use the last 4 bytes to pass the pid_t back, which leaves a 3 hole byte. We want the u8 to remain at the current position to keep this interface functional in case of a version mismatch, and the pid should stay 32bit aligned, hence the hole.

A small test modification validates the correct pid was observed during testing for one of the cases.