### PR TITLE
Ignore data_version in scoutfs_ioc_data_wait_err.

### DIFF
--- a/kmod/src/ioctl.c
+++ b/kmod/src/ioctl.c
@@ -441,8 +441,6 @@ static long scoutfs_ioc_data_wait_err(struct file *file, unsigned long arg)
 
 	if (!S_ISREG(inode->i_mode)) {
 		ret = -EINVAL;
-	} else if (scoutfs_inode_data_version(inode) != args.data_version) {
-		ret = -ESTALE;
 	} else {
 		ret = scoutfs_data_wait_err(inode, sblock, eblock, args.op,
 					    args.err);

--- a/kmod/src/ioctl.h
+++ b/kmod/src/ioctl.h
@@ -366,10 +366,15 @@ struct scoutfs_ioctl_statfs_more {
  *
  * Find current waiters that match the inode, op, and block range to wake
  * up and return an error.
+ *
+ * (*) ca. v1.25 and earlier required that the data_version passed match
+ * that of the waiter, but this check is removed. It was never needed
+ * because no data is modified during this ioctl. Any data_version value
+ * here is thus since then ignored.
  */
 struct scoutfs_ioctl_data_wait_err {
 	__u64 ino;
-	__u64 data_version;
+	__u64 data_version; /* Ignored, see above (*) */
 	__u64 offset;
 	__u64 count;
 	__u64 op;


### PR DESCRIPTION
The data_wait_err ioctl currently requires the correct data_version for the inode to be passed in, or else the ioctl returns -ESTALE. But the ioctl itself is just a passthrough mechanism for notifying data waiters, which doesn't involve the data_version at all.

Instead, we can just drop checking the value. The field remains in the headers, but we've marked it as being ignored from now on.

This all is a lot simpler than having to modify/rev the data_waiters interface to support passing back the data_version, because there isn't any space left to easily do this, and then userspace would just pass it back to the data_wait_err ioctl.