### PR TITLE
ipv6 support.

### DIFF
--- a/kmod/src/client.c
+++ b/kmod/src/client.c
@@ -479,7 +479,7 @@ static void scoutfs_client_connect_worker(struct work_struct *work)
 	struct scoutfs_sb_info *sbi = SCOUTFS_SB(sb);
 	struct scoutfs_mount_options opts;
 	struct scoutfs_net_greeting greet;
-	struct sockaddr_in sin;
+	struct sockaddr_storage sin;
 	bool am_quorum;
 	int ret;
 

--- a/kmod/src/fence.h
+++ b/kmod/src/fence.h
@@ -7,7 +7,7 @@ enum {
 	SCOUTFS_FENCE_QUORUM_BLOCK_LEADER,
 };
 
-int scoutfs_fence_start(struct super_block *sb, u64 rid, __be32 ipv4_addr, int reason);
+int scoutfs_fence_start(struct super_block *sb, u64 rid, union scoutfs_inet_addr *addr, int reason);
 int scoutfs_fence_next(struct super_block *sb, u64 *rid, int *reason, bool *error);
 int scoutfs_fence_reason_pending(struct super_block *sb, int reason);
 int scoutfs_fence_free(struct super_block *sb, u64 rid);

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -195,9 +195,11 @@ struct kc_shrinker_wrapper {
 #include <linux/inet.h>
 static inline int kc_kernel_getsockname(struct socket *sock, struct sockaddr *addr)
 {
-	int addrlen = sizeof(struct sockaddr_in);
+	int addrlen = sizeof(struct sockaddr_storage);
 	int ret = kernel_getsockname(sock, addr, &addrlen);
-	if (ret == 0 && addrlen != sizeof(struct sockaddr_in))
+	if (ret == 0 && (!(
+	    (addrlen == sizeof(struct sockaddr_in)) ||
+	    (addrlen == sizeof(struct sockaddr_in6)))))
 		return -EAFNOSUPPORT;
 	else if (ret < 0)
 		return ret;
@@ -206,9 +208,11 @@ static inline int kc_kernel_getsockname(struct socket *sock, struct sockaddr *ad
 }
 static inline int kc_kernel_getpeername(struct socket *sock, struct sockaddr *addr)
 {
-	int addrlen = sizeof(struct sockaddr_in);
+	int addrlen = sizeof(struct sockaddr_storage);
 	int ret = kernel_getpeername(sock, addr, &addrlen);
-	if (ret == 0 && addrlen != sizeof(struct sockaddr_in))
+	if (ret == 0 && (!(
+	    (addrlen == sizeof(struct sockaddr_in)) ||
+	    (addrlen == sizeof(struct sockaddr_in6)))))
 		return -EAFNOSUPPORT;
 	else if (ret < 0)
 		return ret;

--- a/kmod/src/quorum.c
+++ b/kmod/src/quorum.c
@@ -145,14 +145,26 @@ struct quorum_info {
 #define DECLARE_QUORUM_INFO_KOBJ(kobj, name) \
 	DECLARE_QUORUM_INFO(SCOUTFS_SYSFS_ATTRS_SB(kobj), name)
 
-static bool quorum_slot_present(struct scoutfs_quorum_config *qconf, int i)
+static bool quorum_slot_ipv4(struct scoutfs_quorum_config *qconf, int i)
 {
 	BUG_ON(i < 0 || i > SCOUTFS_QUORUM_MAX_SLOTS);
 
 	return qconf->slots[i].addr.v4.family == cpu_to_le16(SCOUTFS_AF_IPV4);
 }
 
-static void quorum_slot_sin(struct scoutfs_quorum_config *qconf, int i, struct sockaddr_in *sin)
+static bool quorum_slot_ipv6(struct scoutfs_quorum_config *qconf, int i)
+{
+	BUG_ON(i < 0 || i > SCOUTFS_QUORUM_MAX_SLOTS);
+
+	return qconf->slots[i].addr.v6.family == cpu_to_le16(SCOUTFS_AF_IPV6);
+}
+
+static bool quorum_slot_present(struct scoutfs_quorum_config *qconf, int i)
+{
+	return quorum_slot_ipv4(qconf, i) || quorum_slot_ipv6(qconf, i);
+}
+
+static void quorum_slot_sin(struct scoutfs_quorum_config *qconf, int i, struct sockaddr_storage *sin)
 {
 	BUG_ON(i < 0 || i >= SCOUTFS_QUORUM_MAX_SLOTS);
 
@@ -179,11 +191,18 @@ static int create_socket(struct super_block *sb)
 {
 	DECLARE_QUORUM_INFO(sb, qinf);
 	struct socket *sock = NULL;
-	struct sockaddr_in sin;
+	struct sockaddr_storage sin;
+	struct scoutfs_quorum_slot slot = qinf->qconf.slots[qinf->our_quorum_slot_nr];
 	int addrlen;
 	int ret;
 
-	ret = kc_sock_create_kern(PF_INET, SOCK_DGRAM, IPPROTO_UDP, &sock);
+	if (le16_to_cpu(slot.addr.v4.family) == SCOUTFS_AF_IPV4)
+		ret = kc_sock_create_kern(PF_INET, SOCK_DGRAM, IPPROTO_UDP, &sock);
+	else if (le16_to_cpu(slot.addr.v6.family) == SCOUTFS_AF_IPV6)
+		ret = kc_sock_create_kern(PF_INET6, SOCK_DGRAM, IPPROTO_UDP, &sock);
+	else
+		BUG();
+
 	if (ret) {
 		scoutfs_err(sb, "quorum couldn't create udp socket: %d", ret);
 		goto out;
@@ -192,9 +211,9 @@ static int create_socket(struct super_block *sb)
 	/* rather fail and retry than block waiting for free */
 	sock->sk->sk_allocation = GFP_ATOMIC;
 
+	addrlen = (le16_to_cpu(slot.addr.v4.family) == SCOUTFS_AF_IPV4) ?
+		  sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
 	quorum_slot_sin(&qinf->qconf, qinf->our_quorum_slot_nr, &sin);
-
-	addrlen = sizeof(sin);
 	ret = kernel_bind(sock, (struct sockaddr *)&sin, addrlen);
 	if (ret) {
 		scoutfs_err(sb, "quorum failed to bind udp socket to "SIN_FMT": %d",
@@ -241,7 +260,7 @@ static int send_msg_members(struct super_block *sb, int type, u64 term, int only
 		.iov_base = &qmes,
 		.iov_len = sizeof(qmes),
 	};
-	struct sockaddr_in sin;
+	struct sockaddr_storage sin;
 	struct msghdr mh = {
 		.msg_flags = MSG_DONTWAIT | MSG_NOSIGNAL,
 		.msg_name = &sin,
@@ -545,7 +564,8 @@ int scoutfs_quorum_fence_leaders(struct super_block *sb, struct scoutfs_quorum_c
 	struct scoutfs_quorum_block_event (*old)[NR_OLD];
 	struct scoutfs_sb_info *sbi = SCOUTFS_SB(sb);
 	struct scoutfs_quorum_block blk;
-	struct sockaddr_in sin;
+	struct sockaddr_storage sin;
+	union scoutfs_inet_addr addr;
 	const __le64 lefsid = cpu_to_le64(sbi->fsid);
 	const u64 rid = sbi->rid;
 	bool fence_started = false;
@@ -605,7 +625,8 @@ int scoutfs_quorum_fence_leaders(struct super_block *sb, struct scoutfs_quorum_c
 			scoutfs_info(sb, "fencing previous leader "SCSBF" at term %llu in slot %u with address "SIN_FMT,
 				     SCSB_LEFR_ARGS(lefsid, fence_rid),
 				     le64_to_cpu(old[i][j].term), i, SIN_ARG(&sin));
-			ret = scoutfs_fence_start(sb, le64_to_cpu(fence_rid), sin.sin_addr.s_addr,
+			scoutfs_sin_to_addr(&addr, &sin);
+			ret = scoutfs_fence_start(sb, le64_to_cpu(fence_rid), &addr,
 						  SCOUTFS_FENCE_QUORUM_BLOCK_LEADER);
 			if (ret < 0)
 				goto out_free;
@@ -717,7 +738,7 @@ static void scoutfs_quorum_worker(struct work_struct *work)
 	struct quorum_info *qinf = container_of(work, struct quorum_info, work);
 	struct scoutfs_mount_options opts;
 	struct super_block *sb = qinf->sb;
-	struct sockaddr_in unused;
+	struct sockaddr_storage unused;
 	struct quorum_host_msg msg;
 	struct quorum_status qst = {0,};
 	struct hb_recording hbr;
@@ -999,7 +1020,7 @@ out:
  * leader with the greatest elected term.  If we get it wrong the
  * connection will timeout and the client will try again.
  */
-int scoutfs_quorum_server_sin(struct super_block *sb, struct sockaddr_in *sin)
+int scoutfs_quorum_server_sin(struct super_block *sb, struct sockaddr_storage *sin)
 {
 	struct scoutfs_super_block *super = NULL;
 	struct scoutfs_quorum_block blk;
@@ -1058,7 +1079,7 @@ u8 scoutfs_quorum_votes_needed(struct super_block *sb)
 	return qinf->votes_needed;
 }
 
-void scoutfs_quorum_slot_sin(struct scoutfs_quorum_config *qconf, int i, struct sockaddr_in *sin)
+void scoutfs_quorum_slot_sin(struct scoutfs_quorum_config *qconf, int i, struct sockaddr_storage *sin)
 {
 	return quorum_slot_sin(qconf, i, sin);
 }
@@ -1217,8 +1238,12 @@ static int verify_quorum_slots(struct super_block *sb, struct quorum_info *qinf,
 			       struct scoutfs_quorum_config *qconf)
 {
 	char slots[(SCOUTFS_QUORUM_MAX_SLOTS * 3) + 1];
-	struct sockaddr_in other;
-	struct sockaddr_in sin;
+	struct sockaddr_storage other;
+	struct sockaddr_storage sin;
+	struct sockaddr_in *sin4;
+	struct sockaddr_in *other4;
+	struct sockaddr_in6 *sin6;
+	struct sockaddr_in6 *other6;
 	int found = 0;
 	int ret;
 	int i;
@@ -1229,35 +1254,78 @@ static int verify_quorum_slots(struct super_block *sb, struct quorum_info *qinf,
 		if (!quorum_slot_present(qconf, i))
 			continue;
 
-		scoutfs_quorum_slot_sin(qconf, i, &sin);
+		if (quorum_slot_ipv4(qconf, i)) {
+			scoutfs_quorum_slot_sin(qconf, i, &sin);
+			sin4 = (struct sockaddr_in *)&sin;
 
-		if (!valid_ipv4_unicast(sin.sin_addr.s_addr)) {
-			scoutfs_err(sb, "quorum slot #%d has invalid ipv4 unicast address: "SIN_FMT,
-				    i,  SIN_ARG(&sin));
-			return -EINVAL;
-		}
-
-		if (!valid_ipv4_port(sin.sin_port)) {
-			scoutfs_err(sb, "quorum slot #%d has invalid ipv4 port number:"SIN_FMT,
-				    i,  SIN_ARG(&sin));
-			return -EINVAL;
-		}
-
-		for (j = i + 1; j < SCOUTFS_QUORUM_MAX_SLOTS; j++) {
-			if (!quorum_slot_present(qconf, j))
-				continue;
-
-			scoutfs_quorum_slot_sin(qconf, j, &other);
-
-			if (sin.sin_addr.s_addr == other.sin_addr.s_addr &&
-			    sin.sin_port == other.sin_port) {
-				scoutfs_err(sb, "quorum slots #%u and #%u have the same address: "SIN_FMT,
-					    i, j, SIN_ARG(&sin));
+			if (!valid_ipv4_unicast(sin4->sin_addr.s_addr)) {
+				scoutfs_err(sb, "quorum slot #%d has invalid ipv4 unicast address: "SIN_FMT,
+					    i, SIN_ARG(&sin));
 				return -EINVAL;
 			}
-		}
 
-		found++;
+			if (!valid_ipv4_port(sin4->sin_port)) {
+				scoutfs_err(sb, "quorum slot #%d has invalid ipv4 port number:"SIN_FMT,
+					    i, SIN_ARG(&sin));
+				return -EINVAL;
+			}
+
+			for (j = i + 1; j < SCOUTFS_QUORUM_MAX_SLOTS; j++) {
+				if (!quorum_slot_ipv4(qconf, j))
+					continue;
+
+				scoutfs_quorum_slot_sin(qconf, j, &other);
+				other4 = (struct sockaddr_in *)&other;
+
+				if (sin4->sin_addr.s_addr == other4->sin_addr.s_addr &&
+				    sin4->sin_port == other4->sin_port) {
+					scoutfs_err(sb, "quorum slots #%u and #%u have the same address: "SIN_FMT,
+						    i, j, SIN_ARG(&sin));
+					return -EINVAL;
+				}
+			}
+
+			found++;
+		} else if (quorum_slot_ipv6(qconf, i)) {
+			quorum_slot_sin(qconf, i, &sin);
+			sin6 = (struct sockaddr_in6 *)&sin;
+
+			if ((sin6->sin6_addr.in6_u.u6_addr32[0] == 0) && (sin6->sin6_addr.in6_u.u6_addr32[1] == 0) &&
+			    (sin6->sin6_addr.in6_u.u6_addr32[2] == 0) && (sin6->sin6_addr.in6_u.u6_addr32[3] == 0)) {
+				scoutfs_err(sb, "quorum slot #%d has unspecified ipv6 address:"SIN_FMT,
+					    i, SIN_ARG(&sin));
+				return -EINVAL;
+			}
+
+			if (sin6->sin6_addr.in6_u.u6_addr8[0] == 0xff) {
+				scoutfs_err(sb, "quorum slot #%d has multicast ipv6 address:"SIN_FMT,
+					    i, SIN_ARG(&sin));
+				return -EINVAL;
+			}
+
+			if (!valid_ipv4_port(sin6->sin6_port)) {
+				scoutfs_err(sb, "quorum slot #%d has invalid ipv6 port number:"SIN_FMT,
+					    i,  SIN_ARG(&sin));
+				return -EINVAL;
+			}
+
+			for (j = i + 1; j < SCOUTFS_QUORUM_MAX_SLOTS; j++) {
+				if (!quorum_slot_ipv6(qconf, j))
+					continue;
+
+				quorum_slot_sin(qconf, j, &other);
+				other6 = (struct sockaddr_in6 *)&other;
+
+				if ((ipv6_addr_equal(&sin6->sin6_addr, &other6->sin6_addr)) &&
+				    (sin6->sin6_port == other6->sin6_port)) {
+					scoutfs_err(sb, "quorum slots #%u and #%u have the same address: "SIN_FMT,
+						    i, j, SIN_ARG(&sin));
+					return -EINVAL;
+				}
+			}
+
+			found++;
+		}
 	}
 
 	if (found == 0)  {

--- a/kmod/src/quorum.c
+++ b/kmod/src/quorum.c
@@ -1244,6 +1244,7 @@ static int verify_quorum_slots(struct super_block *sb, struct quorum_info *qinf,
 	struct sockaddr_in *other4;
 	struct sockaddr_in6 *sin6;
 	struct sockaddr_in6 *other6;
+	__le16 family = cpu_to_le16(SCOUTFS_AF_NONE);
 	int found = 0;
 	int ret;
 	int i;
@@ -1255,6 +1256,14 @@ static int verify_quorum_slots(struct super_block *sb, struct quorum_info *qinf,
 			continue;
 
 		if (quorum_slot_ipv4(qconf, i)) {
+			if (family == cpu_to_le16(SCOUTFS_AF_NONE)) {
+				family = cpu_to_le16(SCOUTFS_AF_IPV4);
+			} else if (family != cpu_to_le16(SCOUTFS_AF_IPV4)) {
+				scoutfs_err(sb, "quorum slot #%d is IPv4 but earlier slots are IPv6; mixed IPv4/IPv6 quorum is not supported",
+					    i);
+				return -EINVAL;
+			}
+
 			scoutfs_quorum_slot_sin(qconf, i, &sin);
 			sin4 = (struct sockaddr_in *)&sin;
 
@@ -1287,6 +1296,14 @@ static int verify_quorum_slots(struct super_block *sb, struct quorum_info *qinf,
 
 			found++;
 		} else if (quorum_slot_ipv6(qconf, i)) {
+			if (family == cpu_to_le16(SCOUTFS_AF_NONE)) {
+				family = cpu_to_le16(SCOUTFS_AF_IPV6);
+			} else if (family != cpu_to_le16(SCOUTFS_AF_IPV6)) {
+				scoutfs_err(sb, "quorum slot #%d is IPv6 but earlier slots are IPv4; mixed IPv4/IPv6 quorum is not supported",
+					    i);
+				return -EINVAL;
+			}
+
 			quorum_slot_sin(qconf, i, &sin);
 			sin6 = (struct sockaddr_in6 *)&sin;
 

--- a/kmod/src/quorum.h
+++ b/kmod/src/quorum.h
@@ -1,11 +1,11 @@
 #ifndef _SCOUTFS_QUORUM_H_
 #define _SCOUTFS_QUORUM_H_
 
-int scoutfs_quorum_server_sin(struct super_block *sb, struct sockaddr_in *sin);
+int scoutfs_quorum_server_sin(struct super_block *sb, struct sockaddr_storage *sin);
 
 u8 scoutfs_quorum_votes_needed(struct super_block *sb);
 void scoutfs_quorum_slot_sin(struct scoutfs_quorum_config *qconf, int i,
-			     struct sockaddr_in *sin);
+			     struct sockaddr_storage *sin);
 
 int scoutfs_quorum_fence_leaders(struct super_block *sb, struct scoutfs_quorum_config *qconf,
 				 u64 term);

--- a/kmod/src/scoutfs_trace.h
+++ b/kmod/src/scoutfs_trace.h
@@ -1355,35 +1355,37 @@ DEFINE_EVENT(scoutfs_lock_class, scoutfs_lock_shrink,
 );
 
 DECLARE_EVENT_CLASS(scoutfs_net_class,
-        TP_PROTO(struct super_block *sb, struct sockaddr_in *name,
-		 struct sockaddr_in *peer, struct scoutfs_net_header *nh),
+        TP_PROTO(struct super_block *sb, struct sockaddr_storage *name,
+		 struct sockaddr_storage *peer, struct scoutfs_net_header *nh),
         TP_ARGS(sb, name, peer, nh),
         TP_STRUCT__entry(
 		SCSB_TRACE_FIELDS
-		si4_trace_define(name)
-		si4_trace_define(peer)
+		__field_struct(struct sockaddr_storage, name)
+		__field_struct(struct sockaddr_storage, peer)
 		snh_trace_define(nh)
         ),
         TP_fast_assign(
 		SCSB_TRACE_ASSIGN(sb);
-		si4_trace_assign(name, name);
-		si4_trace_assign(peer, peer);
+		memcpy(&__entry->name, name, sizeof(struct sockaddr_storage));
+		memcpy(&__entry->peer, peer, sizeof(struct sockaddr_storage));
 		snh_trace_assign(nh, nh);
         ),
-        TP_printk(SCSBF" name "SI4_FMT" peer "SI4_FMT" nh "SNH_FMT,
-		  SCSB_TRACE_ARGS, si4_trace_args(name), si4_trace_args(peer),
+        TP_printk(SCSBF" name "SIN_FMT" peer "SIN_FMT" nh "SNH_FMT,
+		  SCSB_TRACE_ARGS,
+		  &__entry->name,
+		  &__entry->peer,
 		  snh_trace_args(nh))
 );
 
 DEFINE_EVENT(scoutfs_net_class, scoutfs_net_send_message,
-        TP_PROTO(struct super_block *sb, struct sockaddr_in *name,
-		 struct sockaddr_in *peer, struct scoutfs_net_header *nh),
+        TP_PROTO(struct super_block *sb, struct sockaddr_storage *name,
+		 struct sockaddr_storage *peer, struct scoutfs_net_header *nh),
         TP_ARGS(sb, name, peer, nh)
 );
 
 DEFINE_EVENT(scoutfs_net_class, scoutfs_net_recv_message,
-        TP_PROTO(struct super_block *sb, struct sockaddr_in *name,
-		 struct sockaddr_in *peer, struct scoutfs_net_header *nh),
+        TP_PROTO(struct super_block *sb, struct sockaddr_storage *name,
+		 struct sockaddr_storage *peer, struct scoutfs_net_header *nh),
         TP_ARGS(sb, name, peer, nh)
 );
 
@@ -1416,8 +1418,8 @@ DECLARE_EVENT_CLASS(scoutfs_net_conn_class,
 		__field(void *, sock)
 		__field(__u64, c_rid)
 		__field(__u64, greeting_id)
-		si4_trace_define(sockname)
-		si4_trace_define(peername)
+		__field_struct(struct sockaddr_storage, sockname)
+		__field_struct(struct sockaddr_storage, peername)
 		__field(unsigned char, e_accepted_head)
 		__field(void *, listening_conn)
 		__field(unsigned char, e_accepted_list)
@@ -1435,8 +1437,8 @@ DECLARE_EVENT_CLASS(scoutfs_net_conn_class,
 		__entry->sock = conn->sock;
 		__entry->c_rid = conn->rid;
 		__entry->greeting_id = conn->greeting_id;
-		si4_trace_assign(sockname, &conn->sockname);
-		si4_trace_assign(peername, &conn->peername);
+		memcpy(&__entry->sockname, &conn->sockname, sizeof(struct sockaddr_storage));
+		memcpy(&__entry->peername, &conn->peername, sizeof(struct sockaddr_storage));
 		__entry->e_accepted_head = !!list_empty(&conn->accepted_head);
 		__entry->listening_conn = conn->listening_conn;
 		__entry->e_accepted_list = !!list_empty(&conn->accepted_list);
@@ -1446,7 +1448,7 @@ DECLARE_EVENT_CLASS(scoutfs_net_conn_class,
 		__entry->e_resend_queue = !!list_empty(&conn->resend_queue);
 		__entry->recv_seq = atomic64_read(&conn->recv_seq);
         ),
-        TP_printk(SCSBF" flags %s rc_dl %lu cto %lu sk %p rid %llu grid %llu sn "SI4_FMT" pn "SI4_FMT" eah %u lc %p eal %u nss %llu nsi %llu esq %u erq %u rs %llu",
+        TP_printk(SCSBF" flags %s rc_dl %lu cto %lu sk %p rid %llu grid %llu sn "SIN_FMT" pn "SIN_FMT" eah %u lc %p eal %u nss %llu nsi %llu esq %u erq %u rs %llu",
 		  SCSB_TRACE_ARGS,
 		  print_conn_flags(__entry->flags),
 		  __entry->reconn_deadline,
@@ -1454,8 +1456,8 @@ DECLARE_EVENT_CLASS(scoutfs_net_conn_class,
 		  __entry->sock,
 		  __entry->c_rid,
 		  __entry->greeting_id,
-		  si4_trace_args(sockname),
-		  si4_trace_args(peername),
+		  &__entry->sockname,
+		  &__entry->peername,
 		  __entry->e_accepted_head,
 		  __entry->listening_conn,
 		  __entry->e_accepted_list,

--- a/kmod/src/server.c
+++ b/kmod/src/server.c
@@ -3639,7 +3639,7 @@ static bool invalid_mounted_client_item(struct scoutfs_btree_item_ref *iref)
  * it's acceptable to see -EEXIST.
  */
 static int insert_mounted_client(struct super_block *sb, u64 rid, u64 gr_flags,
-				 struct sockaddr_in *sin)
+				 struct sockaddr_storage *sin)
 {
 	DECLARE_SERVER_INFO(sb, server);
 	struct scoutfs_super_block *super = DIRTY_SUPER_SB(sb);
@@ -4392,7 +4392,7 @@ static void fence_pending_recov_worker(struct work_struct *work)
 			break;
 		}
 
-		ret = scoutfs_fence_start(sb, rid, le32_to_be32(addr.v4.addr),
+		ret = scoutfs_fence_start(sb, rid, &addr,
 					  SCOUTFS_FENCE_CLIENT_RECOVERY);
 		if (ret < 0) {
 			scoutfs_err(sb, "fence returned err %d, shutting down server", ret);
@@ -4543,7 +4543,7 @@ static void scoutfs_server_worker(struct work_struct *work)
 	struct scoutfs_net_connection *conn = NULL;
 	struct scoutfs_mount_options opts;
 	DECLARE_WAIT_QUEUE_HEAD(waitq);
-	struct sockaddr_in sin;
+	struct sockaddr_storage sin;
 	bool alloc_init = false;
 	u64 max_seq;
 	int ret;
@@ -4552,7 +4552,7 @@ static void scoutfs_server_worker(struct work_struct *work)
 
 	scoutfs_options_read(sb, &opts);
 	scoutfs_quorum_slot_sin(&server->qconf, opts.quorum_slot_nr, &sin);
-	scoutfs_info(sb, "server starting at "SIN_FMT, SIN_ARG(&sin));
+	scoutfs_info(sb, "server starting at "SIN_FMT, &sin);
 
 	scoutfs_block_writer_init(sb, &server->wri);
 	server->finalize_sent_seq = 0;

--- a/kmod/src/server.h
+++ b/kmod/src/server.h
@@ -1,27 +1,6 @@
 #ifndef _SCOUTFS_SERVER_H_
 #define _SCOUTFS_SERVER_H_
 
-#define SI4_FMT		"%u.%u.%u.%u:%u"
-
-#define si4_trace_define(name)		\
-	__field(__u32, name##_addr)	\
-	__field(__u16, name##_port)
-
-#define si4_trace_assign(name, sin)					\
-do {									\
-	__typeof__(sin) _sin = (sin);					\
-									\
-	__entry->name##_addr = be32_to_cpu(_sin->sin_addr.s_addr);	\
-	__entry->name##_port = be16_to_cpu(_sin->sin_port);		\
-} while(0)
-
-#define si4_trace_args(name)			\
-	(__entry->name##_addr >> 24),		\
-	(__entry->name##_addr >> 16) & 255,	\
-	(__entry->name##_addr >> 8) & 255,	\
-	__entry->name##_addr & 255,		\
-	__entry->name##_port
-
 #define SNH_FMT \
 	"seq %llu recv_seq %llu id %llu data_len %u cmd %u flags 0x%x error %u"
 #define SNH_ARG(nh)							\

--- a/tests/golden/basic-inetaddr
+++ b/tests/golden/basic-inetaddr
@@ -1,0 +1,7 @@
+== mkfs rejects mixed v4/v6 quorum
+rc: 64
+== mkfs all-v4, mount three members, cross-mount signature visible
+== change-quorum-config rejects mixed v4/v6 quorum
+rc: 64
+== switch v4 -> v6, signature survives, cross-mount write again
+== switch v6 -> v4, signatures survive

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -383,7 +383,7 @@ fi
 quo=""
 if [ -n "$T_MKFS" ]; then
 	for i in $(seq -0 $((T_QUORUM - 1))); do
-		quo="$quo -Q $i,127.0.0.1,$((T_TEST_PORT + i))"
+		quo="$quo -Q $i,::1,$((T_TEST_PORT + i))"
 	done
 
 	msg "making new filesystem with $T_QUORUM quorum members"

--- a/tests/sequence
+++ b/tests/sequence
@@ -1,6 +1,7 @@
 export-get-name-parent.sh
 basic-block-counts.sh
 basic-bad-mounts.sh
+basic-inetaddr.sh
 basic-posix-acl.sh
 basic-acl-consistency.sh
 inode-items-updated.sh

--- a/tests/tests/basic-inetaddr.sh
+++ b/tests/tests/basic-inetaddr.sh
@@ -1,0 +1,78 @@
+#
+# Test that mixed ipv4/6 fails through mkfs/quorum change and that
+# users can migrate from ipv4 to v6 and back.
+#
+
+t_require_commands dmsetup blockdev cmp
+
+P0=$T_SCRATCH_PORT
+P1=$((T_SCRATCH_PORT + 1))
+P2=$((T_SCRATCH_PORT + 2))
+SIG=$T_TMP.sig
+seq 1 4096 > "$SIG"
+
+trap '
+	umount $T_TMPDIR/m0 $T_TMPDIR/m1 $T_TMPDIR/m2 2>/dev/null
+	dmsetup remove _bia_m0 _bia_m1 _bia_m2 _bia_d0 _bia_d1 _bia_d2 2>/dev/null
+' EXIT
+
+mkdir -p "$T_TMPDIR/m0" "$T_TMPDIR/m1" "$T_TMPDIR/m2"
+for nv in "m0 $T_EX_META_DEV" "m1 $T_EX_META_DEV" "m2 $T_EX_META_DEV" \
+	  "d0 $T_EX_DATA_DEV" "d1 $T_EX_DATA_DEV" "d2 $T_EX_DATA_DEV"; do
+	set -- $nv
+	t_quiet dmsetup create _bia_$1 --table "0 $(blockdev --getsz $2) linear $2 0"
+done
+
+mnt() {
+mount -t scoutfs \
+	-o metadev_path=/dev/mapper/_bia_m$1,quorum_slot_nr=$1 \
+	/dev/mapper/_bia_d$1 "$T_TMPDIR/m$1"
+}
+mount_all() {
+	mnt 0 &
+	mnt 1 &
+	mnt 2 &
+	wait
+}
+umount_all() {
+	umount $T_TMPDIR/m0 &
+	umount $T_TMPDIR/m1 &
+	umount $T_TMPDIR/m2 &
+	wait
+}
+verify() {
+	cmp -s "$SIG" "$T_TMPDIR/m0/sig" &&
+	cmp -s "$SIG" "$T_TMPDIR/m1/sig" &&
+	cmp -s "$SIG" "$T_TMPDIR/m2/sig" || t_fail "$1"
+}
+
+echo "== mkfs rejects mixed v4/v6 quorum"
+t_rc scoutfs mkfs -f -Q 0,127.0.0.1,$P0 -Q 1,::1,$P1 -Q 2,127.0.0.1,$P2 /dev/mapper/_bia_m0 /dev/mapper/_bia_d0
+
+echo "== mkfs all-v4, mount three members, cross-mount signature visible"
+t_quiet scoutfs mkfs -f -Q 0,127.0.0.1,$P0 -Q 1,127.0.0.1,$P1 -Q 2,127.0.0.1,$P2 /dev/mapper/_bia_m0 /dev/mapper/_bia_d0
+mount_all
+cp "$SIG" "$T_TMPDIR/m0/sig"
+verify "v4 initial"
+umount_all
+
+echo "== change-quorum-config rejects mixed v4/v6 quorum"
+t_rc scoutfs change-quorum-config --offline -Q 0,127.0.0.1,$P0 -Q 1,::1,$P1 -Q 2,127.0.0.1,$P2 /dev/mapper/_bia_m0
+
+echo "== switch v4 -> v6, signature survives, cross-mount write again"
+t_quiet scoutfs change-quorum-config --offline -Q 0,::1,$P0 -Q 1,::1,$P1 -Q 2,::1,$P2 /dev/mapper/_bia_m0
+mount_all
+verify "after v4->v6"
+cp "$SIG" "$T_TMPDIR/m1/sig-v6"
+cmp -s "$SIG" "$T_TMPDIR/m0/sig-v6" || t_fail "v6 cross-mount write not visible on m0"
+cmp -s "$SIG" "$T_TMPDIR/m2/sig-v6" || t_fail "v6 cross-mount write not visible on m2"
+umount_all
+
+echo "== switch v6 -> v4, signatures survive"
+t_quiet scoutfs change-quorum-config --offline -Q 0,127.0.0.1,$P0 -Q 1,127.0.0.1,$P1 -Q 2,127.0.0.1,$P2 /dev/mapper/_bia_m0
+mount_all
+verify "after v6->v4"
+cmp -s "$SIG" "$T_TMPDIR/m0/sig-v6" || t_fail "after v6->v4 sig-v6 lost"
+umount_all
+
+t_pass

--- a/utils/src/quorum.c
+++ b/utils/src/quorum.c
@@ -10,7 +10,8 @@
 
 bool quorum_slot_present(struct scoutfs_super_block *super, int i)
 {
-	return super->qconf.slots[i].addr.v4.family == cpu_to_le16(SCOUTFS_AF_IPV4);
+	return ((super->qconf.slots[i].addr.v4.family == cpu_to_le16(SCOUTFS_AF_IPV4)) ||
+		(super->qconf.slots[i].addr.v6.family == cpu_to_le16(SCOUTFS_AF_IPV6)));
 }
 
 bool valid_quorum_slots(struct scoutfs_quorum_slot *slots)
@@ -18,34 +19,39 @@ bool valid_quorum_slots(struct scoutfs_quorum_slot *slots)
 	struct in_addr in;
 	bool valid = true;
 	char *addr;
+	char ip6addr[INET6_ADDRSTRLEN];
 	int i;
 	int j;
 
 	for (i = 0; i < SCOUTFS_QUORUM_MAX_SLOTS; i++) {
-		if (slots[i].addr.v4.family == cpu_to_le16(SCOUTFS_AF_NONE))
-			continue;
-
-		if (slots[i].addr.v4.family != cpu_to_le16(SCOUTFS_AF_IPV4)) {
+		if (slots[i].addr.v4.family == cpu_to_le16(SCOUTFS_AF_IPV4)) {
+			for (j = i + 1; j < SCOUTFS_QUORUM_MAX_SLOTS; j++) {
+				if (slots[i].addr.v4.addr == slots[j].addr.v4.addr &&
+				    slots[i].addr.v4.port == slots[j].addr.v4.port) {
+					in.s_addr =
+						htonl(le32_to_cpu(slots[i].addr.v4.addr));
+					addr = inet_ntoa(in);
+					fprintf(stderr, "quorum slot nr %u and %u have the same address %s:%u\n",
+						i, j, addr,
+						le16_to_cpu(slots[i].addr.v4.port));
+					valid = false;
+				}
+			}
+		} else if (slots[i].addr.v6.family == cpu_to_le16(SCOUTFS_AF_IPV6)) {
+			for (j = i + 1; j < SCOUTFS_QUORUM_MAX_SLOTS; j++) {
+				if ((IN6_ARE_ADDR_EQUAL(slots[i].addr.v6.addr, slots[j].addr.v6.addr)) &&
+				    (slots[i].addr.v6.port == slots[j].addr.v6.port)) {
+					fprintf(stderr, "quorum slot nr %u and %u have the same address [%s]:%u\n",
+						i, j,
+						inet_ntop(AF_INET6, slots[i].addr.v6.addr, ip6addr, INET6_ADDRSTRLEN),
+						le16_to_cpu(slots[i].addr.v6.port));
+					valid = false;
+				}
+			}
+		} else if (slots[i].addr.v6.family != cpu_to_le16(SCOUTFS_AF_NONE)) {
 			fprintf(stderr, "quorum slot nr %u has invalid family %u\n",
 				i, le16_to_cpu(slots[i].addr.v4.family));
 			valid = false;
-		}
-
-		for (j = i + 1; j < SCOUTFS_QUORUM_MAX_SLOTS; j++) {
-			if (slots[i].addr.v4.family != cpu_to_le16(SCOUTFS_AF_IPV4))
-				continue;
-
-			if (slots[i].addr.v4.addr == slots[j].addr.v4.addr &&
-			    slots[i].addr.v4.port == slots[j].addr.v4.port) {
-
-				in.s_addr =
-					htonl(le32_to_cpu(slots[i].addr.v4.addr));
-				addr = inet_ntoa(in);
-				fprintf(stderr, "quorum slot nr %u and %u have the same address %s:%u\n",
-					i, j, addr,
-					le16_to_cpu(slots[i].addr.v4.port));
-				valid = false;
-			}
 		}
 	}
 
@@ -61,19 +67,23 @@ void print_quorum_slots(struct scoutfs_quorum_slot *slots, int nr, char *indent)
 {
 	struct scoutfs_quorum_slot *sl;
 	struct in_addr in;
+	char ip6addr[INET6_ADDRSTRLEN];
 	bool first = true;
 	int i;
 
 	for (i = 0, sl = slots; i < SCOUTFS_QUORUM_MAX_SLOTS; i++, sl++) {
+		if (sl->addr.v4.family == cpu_to_le16(SCOUTFS_AF_IPV4)) {
+			in.s_addr = htonl(le32_to_cpu(sl->addr.v4.addr));
+			printf("%s%u: %s:%u\n", first ? "" : indent,
+			       i, inet_ntoa(in), le16_to_cpu(sl->addr.v4.port));
 
-		if (sl->addr.v4.family != cpu_to_le16(SCOUTFS_AF_IPV4))
-			continue;
-
-		in.s_addr = htonl(le32_to_cpu(sl->addr.v4.addr));
-		printf("%s%u: %s:%u\n", first ? "" : indent,
-		       i, inet_ntoa(in), le16_to_cpu(sl->addr.v4.port));
-
-		first = false;
+			first = false;
+		} else if (sl->addr.v6.family == cpu_to_le16(SCOUTFS_AF_IPV6)) {
+			printf("%s%u: [%s]:%u\n", first ? "" : indent, i,
+				inet_ntop(AF_INET6, sl->addr.v6.addr, ip6addr, INET6_ADDRSTRLEN),
+				le16_to_cpu(sl->addr.v6.port));
+			first = false;
+		}
 	}
 }
 

--- a/utils/src/quorum.c
+++ b/utils/src/quorum.c
@@ -20,11 +20,20 @@ bool valid_quorum_slots(struct scoutfs_quorum_slot *slots)
 	bool valid = true;
 	char *addr;
 	char ip6addr[INET6_ADDRSTRLEN];
+	__le16 family = cpu_to_le16(SCOUTFS_AF_NONE);
 	int i;
 	int j;
 
 	for (i = 0; i < SCOUTFS_QUORUM_MAX_SLOTS; i++) {
 		if (slots[i].addr.v4.family == cpu_to_le16(SCOUTFS_AF_IPV4)) {
+			if (family == cpu_to_le16(SCOUTFS_AF_NONE)) {
+				family = cpu_to_le16(SCOUTFS_AF_IPV4);
+			} else if (family != cpu_to_le16(SCOUTFS_AF_IPV4)) {
+				fprintf(stderr, "quorum slot nr %u is IPv4 but earlier slots are IPv6; mixed IPv4/IPv6 quorum is not supported\n",
+					i);
+				valid = false;
+			}
+
 			for (j = i + 1; j < SCOUTFS_QUORUM_MAX_SLOTS; j++) {
 				if (slots[i].addr.v4.addr == slots[j].addr.v4.addr &&
 				    slots[i].addr.v4.port == slots[j].addr.v4.port) {
@@ -38,6 +47,14 @@ bool valid_quorum_slots(struct scoutfs_quorum_slot *slots)
 				}
 			}
 		} else if (slots[i].addr.v6.family == cpu_to_le16(SCOUTFS_AF_IPV6)) {
+			if (family == cpu_to_le16(SCOUTFS_AF_NONE)) {
+				family = cpu_to_le16(SCOUTFS_AF_IPV6);
+			} else if (family != cpu_to_le16(SCOUTFS_AF_IPV6)) {
+				fprintf(stderr, "quorum slot nr %u is IPv6 but earlier slots are IPv4; mixed IPv4/IPv6 quorum is not supported\n",
+					i);
+				valid = false;
+			}
+
 			for (j = i + 1; j < SCOUTFS_QUORUM_MAX_SLOTS; j++) {
 				if ((IN6_ARE_ADDR_EQUAL(slots[i].addr.v6.addr, slots[j].addr.v6.addr)) &&
 				    (slots[i].addr.v6.port == slots[j].addr.v6.port)) {


### PR DESCRIPTION
- working mounts, utils, quorum setup
- tests mounts by default using `::1` but scratch mounts are ipv4.
- el7/8 working OK
- tracing prints out ipv6 addresses OK