### PR TITLE
scaling prealloc.

### DIFF
--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -384,6 +384,12 @@ static inline u64 ext_last(struct scoutfs_extent *ext)
  * This can waste a lot of space for small or sparse files but is
  * reasonable when a file population is known to be large and dense but
  * known to be written with non-streaming write patterns.
+ *
+ * In either strategy, preallocation ramps up proportionally with the
+ * file's online block count rather than jumping to the full prealloc
+ * size.  This avoids overallocation for small files in mixed-size
+ * workloads while still allowing large files to benefit from full
+ * preallocation.
  */
 static int alloc_block(struct super_block *sb, struct inode *inode,
 		       struct scoutfs_extent *ext, u64 iblock,
@@ -400,6 +406,7 @@ static int alloc_block(struct super_block *sb, struct inode *inode,
 	struct scoutfs_extent found;
 	struct scoutfs_extent pre = {0,};
 	bool undo_pre = false;
+	bool have_onoff = false;
 	u64 blkno = 0;
 	u64 online;
 	u64 offline;
@@ -445,6 +452,7 @@ static int alloc_block(struct super_block *sb, struct inode *inode,
 		 * blocks.
 		 */
 		scoutfs_inode_get_onoff(inode, &online, &offline);
+		have_onoff = true;
 		if (iblock > 1 && iblock == online) {
 			ret = scoutfs_ext_next(sb, &data_ext_ops, &args,
 					       iblock, 1, &found);
@@ -490,6 +498,16 @@ static int alloc_block(struct super_block *sb, struct inode *inode,
 
 	/* overall prealloc limit */
 	count = min_t(u64, count, opts.data_prealloc_blocks);
+
+	/*
+	 * Ramp preallocation up proportionally with the file's online
+	 * block count rather than jumping to the full prealloc size.
+	 */
+	if (!ext->len) {
+		if (!have_onoff)
+			scoutfs_inode_get_onoff(inode, &online, &offline);
+		count = max_t(u64, 1, min(count, online));
+	}
 
 	ret = scoutfs_alloc_data(sb, datinf->alloc, datinf->wri,
 				 &datinf->dalloc, count, &blkno, &count);

--- a/kmod/src/data.c
+++ b/kmod/src/data.c
@@ -422,6 +422,8 @@ static int alloc_block(struct super_block *sb, struct inode *inode,
 
 	mutex_lock(&datinf->mutex);
 
+	scoutfs_inode_get_onoff(inode, &online, &offline);
+
 	/* default to single allocation at the written block */
 	start = iblock;
 	count = 1;
@@ -444,7 +446,6 @@ static int alloc_block(struct super_block *sb, struct inode *inode,
 		 * the preallocation size to the number of online
 		 * blocks.
 		 */
-		scoutfs_inode_get_onoff(inode, &online, &offline);
 		if (iblock > 1 && iblock == online) {
 			ret = scoutfs_ext_next(sb, &data_ext_ops, &args,
 					       iblock, 1, &found);
@@ -486,6 +487,13 @@ static int alloc_block(struct super_block *sb, struct inode *inode,
 		/* trim count by next extent after iblock */
 		if (found.len && found.start > start && found.start < start + count)
 			count = (found.start - start);
+
+		/*
+		 * Ramp the aligned region size up proportionally with
+		 * the file's online block count rather than jumping to
+		 * the full prealloc size.
+		 */
+		count = max_t(u64, 1, min(count, online));
 	}
 
 	/* overall prealloc limit */

--- a/tests/golden/data-prealloc
+++ b/tests/golden/data-prealloc
@@ -8,10 +8,10 @@
 /mnt/test/test/data-prealloc/file-1: extents: 32
 /mnt/test/test/data-prealloc/file-2: extents: 32
 == any writes to region prealloc get full extents
-/mnt/test/test/data-prealloc/file-1: extents: 4
-/mnt/test/test/data-prealloc/file-2: extents: 4
-/mnt/test/test/data-prealloc/file-1: extents: 4
-/mnt/test/test/data-prealloc/file-2: extents: 4
+/mnt/test/test/data-prealloc/file-1: extents: 8
+/mnt/test/test/data-prealloc/file-2: extents: 8
+/mnt/test/test/data-prealloc/file-1: extents: 8
+/mnt/test/test/data-prealloc/file-2: extents: 8
 == streaming offline writes get full extents either way
 /mnt/test/test/data-prealloc/file-1: extents: 4
 /mnt/test/test/data-prealloc/file-2: extents: 4
@@ -20,8 +20,8 @@
 == goofy preallocation amounts work
 /mnt/test/test/data-prealloc/file-1: extents: 6
 /mnt/test/test/data-prealloc/file-2: extents: 6
-/mnt/test/test/data-prealloc/file-1: extents: 6
-/mnt/test/test/data-prealloc/file-2: extents: 6
+/mnt/test/test/data-prealloc/file-1: extents: 10
+/mnt/test/test/data-prealloc/file-2: extents: 10
 /mnt/test/test/data-prealloc/file-1: extents: 3
 /mnt/test/test/data-prealloc/file-2: extents: 3
 == block writes into region allocs hole


### PR DESCRIPTION
~~Adds an accompanying option to set a data preallocation minimum threshold value. The value can be set through sysfs or at mount time.~~

~~data_prealloc_blocks_min cannot be larger than data_prealloc_blocks, and this is enforced. This should be fine for all common use cases where the _min option is expected to be less than 2048, the default of data_prealloc_blocks.~~

~~Extra test cases are added to validate bad mount option values and sysfs value writes. As well as tests that validate that the minimum threshold is set and honored as expected.~~

Preallocation scales with scoutfs_get_inode_onoff() online values, so that new extents double the online size every allocation until it reaches data_prealloc_blocks. The _onoff() value is only fetched once if possible.