### PR TITLE
Fix double unlock in scoutfs_setattr data_wait error path

### DIFF
--- a/kmod/src/inode.c
+++ b/kmod/src/inode.c
@@ -549,6 +549,7 @@ retry:
 				goto out;
 			if (scoutfs_data_wait_found(&dw)) {
 				scoutfs_unlock(sb, lock, SCOUTFS_LOCK_WRITE);
+				lock = NULL;
 
 				/* XXX callee locks instead? */
 				inode_unlock(inode);


### PR DESCRIPTION
When scoutfs_setattr truncates a file with offline extents, it unlocks the inode lock before calling scoutfs_data_wait to wait for the data to be staged. If data_wait returns any error, the code jumps to 'goto out' which calls scoutfs_unlock again, thus double-unlocking the lock.