### PR TITLE
Add cond_resched in block_free_work

### DIFF
--- a/kmod/src/block.c
+++ b/kmod/src/block.c
@@ -218,6 +218,7 @@ static void block_free_work(struct work_struct *work)
 
 	llist_for_each_entry_safe(bp, tmp, deleted, free_node) {
 		block_free(sb, bp);
+		cond_resched();
 	}
 }
 


### PR DESCRIPTION
I'm seeing consistent CPU soft lockups in block_free_work on my bare metal system that aren't reached by VM instances. The reason is that the bare metal machine has a ton more memory available causing the block free work queue to grow much larger in size, and then it has so much work that it can take 30+ seconds before it goes through it all.

This is all with a debug kernel. A non debug kernel will likely zoom through the outstanding work here at a much faster rate.