### PR TITLE
Squelch gcc uninitialized warning on el7

### DIFF
--- a/kmod/src/wkic.c
+++ b/kmod/src/wkic.c
@@ -922,7 +922,7 @@ static int insert_read_pages(struct super_block *sb, struct wkic_info *winf,
 	struct wkic_page *wpage;
 	LIST_HEAD(pages);
 	u64 merge_input_seq;
-	u64 read_seq;
+	u64 read_seq = 0;
 	int ret;
 
 	ret = 0;


### PR DESCRIPTION
The gcc version in el7 can't determine that scoutfs_block_check_stale won't return ret = 0 when the input ret value is < 0, and errors because we might call alloc_wpage with an uninitialized read_seq. Initialize it to 0 to avoid it.