### PR TITLE
Search all merge range items for next

### DIFF
--- a/kmod/src/server.c
+++ b/kmod/src/server.c
@@ -1077,8 +1077,7 @@ static int next_log_merge_range(struct super_block *sb, struct scoutfs_btree_roo
 	struct scoutfs_key key;
 	int ret;
 
-	key = *start;
-	key.sk_zone = SCOUTFS_LOG_MERGE_RANGE_ZONE;
+	init_log_merge_key(&key, SCOUTFS_LOG_MERGE_RANGE_ZONE, 0, 0);
 	scoutfs_key_set_ones(&rng->start);
 
 	do {


### PR DESCRIPTION
When searching for the next least merge range we need to sweep all the stored items because they're interleaved with respect to key sorting because we've clobbered the zone.

To search all of them we need to start from 0, not from the caller's start key after setting the zone.  If the caller happens to provide a start key with a small zone but large other fields (totl keys with sufficiently large identifiers) we can miss ranges.