### PR TITLE
Clear ref_blkno output when block is already dirty

### DIFF
--- a/kmod/src/block.c
+++ b/kmod/src/block.c
@@ -836,6 +836,9 @@ int scoutfs_block_dirty_ref(struct super_block *sb, struct scoutfs_alloc *alloc,
 	int ret;
 	int err;
 
+	if (ref_blkno)
+		*ref_blkno = 0;
+
 	/* read existing referenced block, if any */
 	blkno = le64_to_cpu(ref->blkno);
 	if (blkno) {


### PR DESCRIPTION
block_dirty_ref() skipped setting *ref_blkno when the block was already dirty, leaving the caller with a stale value passed by reference.

dirty_alloc_blocks() calls it twice but when the referenced block is already dirty, it will receive the uninitialized stack value back, and then adding it freed list with list_block_add() later.

Set it to 0 on the already-dirty fast path so callers do not try to free a random block.