### PR TITLE
Use timer_container_of with fallback for from_timer -> el9.8 support

### DIFF
--- a/kmod/src/Makefile.kernelcompat
+++ b/kmod/src/Makefile.kernelcompat
@@ -496,3 +496,12 @@ endif
 ifneq (,$(shell grep 'struct posix_acl.*get_inode_acl' include/linux/fs.h))
 ccflags-y += -DKC_GET_INODE_ACL
 endif
+
+#
+# v6.15-13744-g41cb08555c41
+#
+# from_timer renamed to timer_container_of.
+#
+ifneq (,$(shell grep 'define timer_container_of' include/linux/timer.h))
+ccflags-y += -DKC_TIMER_CONTAINER_OF
+endif

--- a/kmod/src/fence.c
+++ b/kmod/src/fence.c
@@ -222,7 +222,7 @@ static struct attribute *fence_attrs[] = {
 
 static void fence_timeout(struct timer_list *timer)
 {
-	struct pending_fence *fence = from_timer(fence, timer, timer);
+	struct pending_fence *fence = timer_container_of(fence, timer, timer);
 	struct super_block *sb = fence->sb;
 	DECLARE_FENCE_INFO(sb, fi);
 

--- a/kmod/src/kernelcompat.h
+++ b/kmod/src/kernelcompat.h
@@ -489,4 +489,9 @@ static inline void stack_trace_print(unsigned long *entries, unsigned int nr_ent
 }
 #endif
 
+#ifndef KC_TIMER_CONTAINER_OF
+#define timer_container_of(var, callback_timer, timer_fieldname) \
+	from_timer(var, callback_timer, timer_fieldname)
+#endif
+
 #endif

--- a/kmod/src/recov.c
+++ b/kmod/src/recov.c
@@ -134,7 +134,7 @@ static int recov_finished(struct recov_info *recinf)
 
 static void timer_callback(struct timer_list *timer)
 {
-	struct recov_info *recinf = from_timer(recinf, timer, timer);
+	struct recov_info *recinf = timer_container_of(recinf, timer, timer);
 
 	recinf->timeout_fn(recinf->sb);
 }


### PR DESCRIPTION
El9.8 backported the upstream v6.15.* rename of from_timer to timer_container_of.  Switch the two callers in fence.c and recov.c to the new style and add a simple kcompat define for older kernels.